### PR TITLE
standardize "disable hardcore" warning across emulators

### DIFF
--- a/RAGens/common/src/save.cpp
+++ b/RAGens/common/src/save.cpp
@@ -441,10 +441,6 @@ int Load_Memstate(BYTE *memBuf)
 
 int Save_State(char *Name)
 {
-	// #RA
-    if (!RA_WarnDisableHardcore("save a state"))
-        return 0;
-
 	FILE *f;
 	unsigned char *buf;
 	int len;

--- a/RAGens/common/src/save.cpp
+++ b/RAGens/common/src/save.cpp
@@ -140,10 +140,7 @@ int load_Memstate()
 {
 	// #RA
 	if( RA_HardcoreModeIsActive() )
-	{
-		MessageBox( HWnd, "Please disable Hardcore mode when using REWiND!", "Warning", MB_OK );
 		return 0;
-	}
 
 	if(memstateAllocated == 0)
 		return 0;
@@ -299,11 +296,8 @@ void Get_State_File_Name(char *name)
 int Load_State(char *Name)
 {
 	// #RA
-	if( RA_HardcoreModeIsActive() )
-	{
-		if( MessageBox( HWnd, "Hardcore mode is active. If you load a state, you will disable Hardcore Mode. Continue?", "Warning", MB_YESNO ) == IDNO )
-			return 0;
-	}
+    if (!RA_WarnDisableHardcore("load a state"))
+        return 0;
 
 	FILE *f;
 	unsigned char *buf;
@@ -435,6 +429,10 @@ int Load_Memstate(BYTE *memBuf)
 				RA_OnLoadNewRom( Rom_Data, 6*1024*1024 );
 			}
 		}
+        else
+        {
+            RA_OnLoadState( NULL );
+        }
 
   //}
 
@@ -444,11 +442,8 @@ int Load_Memstate(BYTE *memBuf)
 int Save_State(char *Name)
 {
 	// #RA
-	if( RA_HardcoreModeIsActive() )
-	{
-		if( MessageBox( HWnd, "Hardcore mode is active. If you save a state, you will disable Hardcore Mode. Continue?", "Warning", MB_YESNO ) == IDNO )
-			return 0;
-	}
+    if (!RA_WarnDisableHardcore("save a state"))
+        return 0;
 
 	FILE *f;
 	unsigned char *buf;

--- a/RAMeka/.gitignore
+++ b/RAMeka/.gitignore
@@ -32,10 +32,12 @@ meka/Dist
 *.opendb
 *allegro*.zip
 meka/srcs/projects/msvc/packages
+meka/srcs/BuildVer.h
 *.rap
 /meka/srcs/projects/msvc/.vs/
 
 #misc merge latest junk
+meka/RA_Integration.dll
 meka/RA_Integration_d.dll
 meka/RAmeka.bsc
 meka/RAmeka.exe

--- a/RAMeka/meka/srcs/RA_Implementation.h
+++ b/RAMeka/meka/srcs/RA_Implementation.h
@@ -41,10 +41,6 @@ extern void RA_InitShared();
 //                Emulator RA Integration Wrapper Functions             | 
 //-----------------------------------------------------------------------
 
-//Most of the other emulators define their version in their MakeBuildVer.bat scripts. 
-//But we're using NuGet/Allegro/VS2015 so nothing here is "straightforward"
-#define RAMEKA_VERSION  "0.021"
-
 #include <windows.h> //for WPARAM (kind of wasteful really)
 #include "RA_Interface.h"
 
@@ -65,30 +61,13 @@ void RAMeka_RA_SetPaused(bool bIsPaused);
 void RAMeka_RA_OnSaveStateLoad(char* filename);
 void RAMeka_RA_OnSaveStateSave(char* filename);
 
-void RAMeka_RA_MountMasterSystemROM();
 void RAMeka_RA_MountROM( ConsoleID consoleID );
 
 
 void RAMeka_MakePlaceholderRAMenu();
 void RAMeka_InstallRA();
 
-void RAMeka_ValidateHardcoreMode();
-
 void RAMeka_RA_AchievementsFrameCheck();
-
-
-enum RAMeka_Softcore_Feature {
-	SCF_MEMORY_EDITOR,
-	SCF_DEBUGGER,
-	SCF_CHEAT_FINDER,
-	SCF_SAVE_LOAD,
-//	SCF_LOAD,
-//	SCF_SAVE,
-	SCF_UNKNOWN
-};
-
-bool RAMeka_HardcoreIsActiveCheck(RAMeka_Softcore_Feature current_feature);
-bool RAMeka_HardcoreDeactivateConfirm(RAMeka_Softcore_Feature current_feature);
 
 
 void RAMeka_Config_Load_Line(char *var, char *value);

--- a/RAMeka/meka/srcs/app_cheatfinder.c
+++ b/RAMeka/meka/srcs/app_cheatfinder.c
@@ -619,8 +619,8 @@ void	CheatFinder_SwitchMainInstance()
 
 	//Not sure if hardcore deactivation is really required in case of cheat finder alone
 	//if (!app->active) {
-	//	if (!RAMeka_HardcoreDeactivateConfirm(SCF_CHEAT_FINDER)) {
-	//		return; //user did not agree to a hardcore mode deactivation, abandon debugger activation
+	//	if (!RA_WarnDisableHardcore("find cheats")) {
+	//		return; //user did not agree to a hardcore mode deactivation, abandon cheat finder activation
 	//	}
 	//}
 

--- a/RAMeka/meka/srcs/app_memview.c
+++ b/RAMeka/meka/srcs/app_memview.c
@@ -483,7 +483,7 @@ static void        MemoryViewer_Update(t_memory_viewer* app)
 		return;
 	}
 
-	if (RAMeka_HardcoreIsActiveCheck(SCF_MEMORY_EDITOR)) {
+	if (RA_HardcoreModeIsActive()) {
 		MemoryViewer_SwitchMainInstance();
 		return;
 	}
@@ -646,7 +646,7 @@ void    MemoryViewer_SwitchMainInstance()
     t_memory_viewer* app = MemoryViewer_MainInstance;
 
 	if (!app->active) {
-		if (!RAMeka_HardcoreDeactivateConfirm(SCF_MEMORY_EDITOR)) {
+		if (!RA_WarnDisableHardcore("view memory")) {
 			return; //user did not agree to a hardcore mode deactivation, abandon debugger activation
 		}
 	}

--- a/RAMeka/meka/srcs/debugger.c
+++ b/RAMeka/meka/srcs/debugger.c
@@ -651,7 +651,7 @@ void	Debugger_Update()
 {
     if (Debugger.active)
     {
-		if (RAMeka_HardcoreIsActiveCheck(SCF_DEBUGGER)) {
+		if (RA_HardcoreModeIsActive()) {
 			Debugger_Switch();
 			return;
 		}
@@ -1866,7 +1866,7 @@ void	Debugger_Switch()
         return;
 
 	if (!Debugger.active) {
-		if (! RAMeka_HardcoreDeactivateConfirm(SCF_DEBUGGER)) {
+        if (!RA_WarnDisableHardcore("debug")) {
 			return; //user did not agree to a hardcore mode deactivation, abandon debugger activation
 		}
 	}

--- a/RAMeka/meka/srcs/machine.c
+++ b/RAMeka/meka/srcs/machine.c
@@ -675,6 +675,9 @@ void        Machine_Reset(void)
     #ifdef MEKA_Z80_DEBUGGER
         Debugger_MachineReset();
     #endif
+
+    // RA
+    RA_OnReset();
 }
 
 //-----------------------------------------------------------------------------

--- a/RAMeka/meka/srcs/meka.c
+++ b/RAMeka/meka/srcs/meka.c
@@ -428,10 +428,16 @@ int main(int argc, char **argv)
 	Init_GUI               (); // Initialize Graphical User Interface
 	FB_Init_2              (); // Finish initializing the file browser
 
-	//RA
-	RAMeka_ValidateHardcoreMode	(); // Disable Hardcore mode if required
-
-
+	// RA
+    if (RA_HardcoreModeIsActive())
+    {
+        if (MemoryViewer_MainInstance->active)
+            gui_box_show(MemoryViewer_MainInstance->box, FALSE, FALSE);
+        if (Debugger.enabled)
+            Debugger_Close();
+        if (g_CheatFinder_MainInstance->active)
+            gui_box_show(g_CheatFinder_MainInstance->box, FALSE, FALSE);
+    }
 
     // Load ROM from command line if necessary
     Load_ROM_Command_Line();

--- a/RAMeka/meka/srcs/projects/msvc/MakeBuildVer.bat
+++ b/RAMeka/meka/srcs/projects/msvc/MakeBuildVer.bat
@@ -1,0 +1,33 @@
+@echo off
+
+git describe --tags --match "RAMeka.*" > Temp.txt
+set /p ACTIVE_TAG=<Temp.txt
+set VERSION_NUM=%ACTIVE_TAG:~7,3%
+set VERSION_REVISION=%ACTIVE_TAG:~11,-9%
+if "%VERSION_REVISION%"=="" set VERSION_REVISION=0
+
+setlocal
+git diff HEAD > Temp.txt
+for /F "usebackq" %%A in ('"Temp.txt"') do set DIFF_FILE_SIZE=%%~zA
+if %DIFF_FILE_SIZE% GTR 0 (
+    set ACTIVE_TAG=Unstaged changes
+    set VERSION_MODIFIED=1
+) else (
+    set VERSION_MODIFIED=0
+)
+
+@echo Tag: %ACTIVE_TAG% (%VERSION_NUM%)
+@echo #define RAMEKA_VERSION "0.%VERSION_NUM%.%VERSION_REVISION%.%VERSION_MODIFIED%" > BuildVer2.h
+
+if not exist ..\..\BuildVer.h goto nonexistant
+fc ..\..\BuildVer.h BuildVer2.h > nul
+if errorlevel 1 goto different
+del BuildVer2.h
+goto done
+:different
+del ..\..\BuildVer.h
+:nonexistant
+move BuildVer2.h ..\..\BuildVer.h > nul
+:done
+
+del Temp.txt

--- a/RAMeka/meka/srcs/projects/msvc/Meka.vcxproj
+++ b/RAMeka/meka/srcs/projects/msvc/Meka.vcxproj
@@ -122,6 +122,9 @@
       <EnableDpiAwareness>true</EnableDpiAwareness>
     </Manifest>
     <PostBuildEvent />
+    <PreBuildEvent>
+      <Command>$(ProjectDir)MakeBuildVer.bat</Command>
+    </PreBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <Midl>
@@ -182,6 +185,9 @@
     <CustomBuildStep />
     <Manifest />
     <PostBuildEvent />
+    <PreBuildEvent>
+      <Command>$(ProjectDir)MakeBuildVer.bat</Command>
+    </PreBuildEvent>
   </ItemDefinitionGroup>
   <ItemGroup>
     <None Include="..\..\..\meka.blt" />

--- a/RAMeka/meka/srcs/projects/msvc/Meka.vcxproj.filters
+++ b/RAMeka/meka/srcs/projects/msvc/Meka.vcxproj.filters
@@ -421,9 +421,7 @@
     <ClCompile Include="..\..\RA_Implementation.cpp">
       <Filter>RA_Implementation</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\..\..\..\RA_Integration\RA_Interface.cpp">
-      <Filter>RA_Implementation</Filter>
-    </ClCompile>
+    <ClCompile Include="..\..\..\..\..\RA_Integration\src\RA_Interface.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\allegro4to5.h">
@@ -789,9 +787,7 @@
     <ClInclude Include="..\..\RA_Implementation.h">
       <Filter>RA_Implementation</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\..\..\..\RA_Integration\RA_Interface.h">
-      <Filter>RA_Implementation</Filter>
-    </ClInclude>
+    <ClInclude Include="..\..\..\..\..\RA_Integration\src\RA_Interface.h" />
   </ItemGroup>
   <ItemGroup>
     <ResourceCompile Include="Meka.rc">

--- a/RAMeka/meka/srcs/saves.c
+++ b/RAMeka/meka/srcs/saves.c
@@ -133,10 +133,6 @@ void        Load_Game_Fixup(void)
 void        SaveState_Save()
 {
 
-	if (!RAMeka_HardcoreDeactivateConfirm(SCF_SAVE_LOAD)) {
-		return; //user did not agree to a hardcore mode deactivation, abandon debugger activation
-	}
-
     // Do not allow saving if machine is not running
     if ((g_machine_flags & MACHINE_RUN) != MACHINE_RUN)
     {
@@ -181,10 +177,10 @@ void        SaveState_Save()
 // Load state from current slot
 void        SaveState_Load()
 {
-	
-	if (!RAMeka_HardcoreDeactivateConfirm(SCF_SAVE_LOAD)) {
-		return; //user did not agree to a hardcore mode deactivation, abandon debugger activation
-	}
+    if (!RA_WarnDisableHardcore("load a state"))
+    {
+        return; //user did not agree to a hardcore mode deactivation, abandon debugger activation
+    }
 
     // Do not allow loading if machine is not running
     if ((g_machine_flags & MACHINE_RUN) != MACHINE_RUN)

--- a/RAMeka/meka/srcs/saves.c
+++ b/RAMeka/meka/srcs/saves.c
@@ -160,10 +160,10 @@ void        SaveState_Save()
         fclose (f);
     }
 
-
-    StrPath_RemoveDirectory (buf);
 	//#RA
 	RAMeka_RA_OnSaveStateSave(buf);
+
+    StrPath_RemoveDirectory(buf);
 
 	switch (result)
     {
@@ -218,12 +218,10 @@ void        SaveState_Load()
         fclose (f);
     }
 
-
-
-    StrPath_RemoveDirectory (buf);
-
 	//#RA
 	RAMeka_RA_OnSaveStateLoad(buf);
+
+    StrPath_RemoveDirectory(buf);
 
     switch (result)
     {

--- a/RANes/RA_Implementation/RA_Implementation.cpp
+++ b/RANes/RA_Implementation/RA_Implementation.cpp
@@ -4,6 +4,7 @@
 //	Include any emulator-side headers, externs or functions here
 #include "../Common.h"
 #include "movie.h"
+#include "cheat.h"
 
 // returns -1 if not found
 int GetMenuItemIndex(HMENU hMenu, const char* ItemName)
@@ -77,6 +78,7 @@ void GetEstimatedGameTitle( char* sNameOut )
 void ResetEmulation()
 {
 	FCEUI_StopMovie();
+    FCEU_FlushGameCheats(0, 1);
 	FCEUI_ResetNES();
 }
 

--- a/RANes/src/drivers/win/memview.cpp
+++ b/RANes/src/drivers/win/memview.cpp
@@ -40,6 +40,8 @@
 #include "Win32InputBox.h"
 #include "utils/xstring.h"
 
+#include "RA_Interface.h"
+
 extern Name* lastBankNames;
 extern Name* loadedBankNames;
 extern Name* ramBankNames;
@@ -909,6 +911,10 @@ void InputData(char *input){
 	int addr, i, j, datasize = 0;
 	unsigned char *data;
 	char inputc;
+
+    if (!RA_WarnDisableHardcore("edit memory"))
+        return;
+
 	//char str[100];
 	//mbg merge 7/18/06 added cast:
 	data = (uint8 *)malloc(strlen(input) + 1); //it can't be larger than the input string, so use that as the size

--- a/RANes/src/drivers/win/ram_search.cpp
+++ b/RANes/src/drivers/win/ram_search.cpp
@@ -46,6 +46,8 @@
 #endif
 #include "memview.h"
 
+#include "RA_Interface.h"
+
 bool ShowROM = false;
 
 bool IsHardwareAddressValid(HWAddressType address)
@@ -1744,6 +1746,9 @@ LRESULT CALLBACK RamSearchProc(HWND hDlg, UINT uMsg, WPARAM wParam, LPARAM lPara
 				}	{rv = true; break;}
 				case IDC_C_ADDCHEAT:
 				{
+                    if (!RA_WarnDisableHardcore("add cheats"))
+                        {rv = true; break;}
+
 					HWND ramListControl = GetDlgItem(hDlg,IDC_RAMLIST);
 					int watchItemIndex = ListView_GetNextItem(ramListControl, -1, LVNI_SELECTED);
 					while (watchItemIndex >= 0)

--- a/RANes/src/drivers/win/ramwatch.cpp
+++ b/RANes/src/drivers/win/ramwatch.cpp
@@ -13,6 +13,8 @@ using namespace std;
 #include <commctrl.h>
 #include <string>
 
+#include "RA_Interface.h"
+
 /*
 #include <commctrl.h>
 #pragma comment(lib, "comctl32.lib")
@@ -1203,7 +1205,10 @@ LRESULT CALLBACK RamWatchProc(HWND hDlg, UINT uMsg, WPARAM wParam, LPARAM lParam
 				}
 				case IDC_C_ADDCHEAT:
 				{
-					watchIndex = ListView_GetSelectionMark(GetDlgItem(hDlg,IDC_WATCHLIST));
+                    if (!RA_WarnDisableHardcore("add cheats"))
+                        break;
+
+                    watchIndex = ListView_GetSelectionMark(GetDlgItem(hDlg,IDC_WATCHLIST));
 					if(watchIndex >= 0)
 					{
 						unsigned int address = rswatches[watchIndex].Address;

--- a/RANes/src/drivers/win/replay.cpp
+++ b/RANes/src/drivers/win/replay.cpp
@@ -983,11 +983,8 @@ static BOOL CALLBACK RecordDialogProc(HWND hwndDlg, UINT uMsg, WPARAM wParam, LP
 //Show the record movie dialog and record a movie.
 void FCEUD_MovieRecordTo()
 {
-	if (RA_HardcoreModeIsActive())
-	{
-		MessageBox(nullptr, ("Hardcore Mode is active. Movie Recording/Playback is disabled."), ("Warning"), MB_OK);
-		return;
-	}
+    if (!RA_WarnDisableHardcore("record a movie"))
+        return;
 
 	if (!GameInfo) return;
 	static struct CreateMovieParameters p;
@@ -1046,11 +1043,8 @@ void Replay_LoadMovie()
 /// Show movie replay dialog and replay the movie if necessary.
 void FCEUD_MovieReplayFrom()
 {
-	if (RA_HardcoreModeIsActive())
-	{
-		MessageBox(nullptr, ("Hardcore Mode is active. Movie Recording/Playback is disabled."), ("Warning"), MB_OK);
-		return;
-	}
+    if (!RA_WarnDisableHardcore("playback a recording"))
+        return;
 
 	if (GameInfo) Replay_LoadMovie();
 }

--- a/RANes/src/drivers/win/window.cpp
+++ b/RANes/src/drivers/win/window.cpp
@@ -201,7 +201,6 @@ void SetMainWindowText()
 	{
 		//Add the filename to the window caption
 		extern char FileBase[];
-		str.append(": ");
 		str.append(FileBase);
 		if (FCEUMOV_IsLoaded())
 		{

--- a/RANes/src/fceu.cpp
+++ b/RANes/src/fceu.cpp
@@ -510,7 +510,7 @@ FCEUGI *FCEUI_LoadGameVirtual(const char *name, int OverwriteVidMode, bool silen
 	FCEU_ResetPalette();
 	FCEU_ResetMessages();   // Save state, status messages, etc.
 
-	if (GameInfo->type != GIT_NSF)
+	if (GameInfo->type != GIT_NSF && !RA_HardcoreModeIsActive())
 		FCEU_LoadGameCheats(0);
 
 	if (AutoResumePlay && !RA_HardcoreModeIsActive())
@@ -834,7 +834,9 @@ void PowerNES(void) {
 #ifdef WIN32
 	ResetDebugStatisticsCounters();
 #endif
-	FCEU_PowerCheats();
+    if (!RA_HardcoreModeIsActive())
+    	FCEU_PowerCheats();
+
 	LagCounterReset();
 	// clear back buffer
 	extern uint8 *XBackBuf;

--- a/RANes/src/fceu.cpp
+++ b/RANes/src/fceu.cpp
@@ -152,7 +152,7 @@ static void FCEU_CloseGame(void)
 {
 	if (GameInfo)
 	{
-		if (AutoResumePlay)
+		if (AutoResumePlay && !RA_HardcoreModeIsActive())
 		{
 			// save "-resume" savestate
 			FCEUSS_Save(FCEU_MakeFName(FCEUMKF_RESUMESTATE, 0, 0).c_str(), false);
@@ -513,7 +513,7 @@ FCEUGI *FCEUI_LoadGameVirtual(const char *name, int OverwriteVidMode, bool silen
 	if (GameInfo->type != GIT_NSF)
 		FCEU_LoadGameCheats(0);
 
-	if (AutoResumePlay)
+	if (AutoResumePlay && !RA_HardcoreModeIsActive())
 	{
 		// load "-resume" savestate
 		if (FCEUSS_Load(FCEU_MakeFName(FCEUMKF_RESUMESTATE, 0, 0).c_str(), false))
@@ -1003,7 +1003,7 @@ void UpdateAutosave(void) {
 }
 
 void FCEUI_RewindToLastAutosave(void) {
-	if (!EnableAutosave || !AutoSS)
+	if (!EnableAutosave || !AutoSS || !RA_HardcoreModeIsActive())
 		return;
 
 	if (AutosaveStatus[AutosaveIndex] == 1) {

--- a/RANes/src/state.cpp
+++ b/RANes/src/state.cpp
@@ -456,12 +456,6 @@ bool FCEUSS_SaveMS(EMUFILE* outstream, int compressionLevel)
 
 void FCEUSS_Save(const char *fname, bool display_message)
 {
-	if( RA_HardcoreModeIsActive() )
-	{
-		if( MessageBox( NULL, "Hardcore mode is active. If you load/save a state, Hardcore Mode will be disabled. Continue?", "Warning", MB_YESNO ) == IDNO )
-			return;
-	}
-
 	EMUFILE* st = 0;
 	char fn[2048];
 
@@ -726,12 +720,6 @@ bool FCEUSS_Load(const char *fname, bool display_message)
 	EMUFILE* st;
 	char fn[2048];
 
-	if( RA_HardcoreModeIsActive() )
-	{
-		if( MessageBox( NULL, "Hardcore mode is active. If you load/save a state, Hardcore Mode will be disabled. Continue?", "Warning", MB_YESNO ) == IDNO )
-			return false;
-	}
-
 	//mbg movie - this needs to be overhauled
 	////this fixes read-only toggle problems
 	//if(FCEUMOV_IsRecording()) {
@@ -955,6 +943,8 @@ void FCEUI_SaveState(const char *fname, bool display_message)
 {
 	if(!FCEU_IsValidUI(FCEUI_SAVESTATE)) return;
 
+    if(!RA_WarnDisableHardcore("save a state")) return;
+
 	StateShow = 0;
 
 	FCEUSS_Save(fname, display_message);
@@ -974,6 +964,8 @@ bool file_exists(const char * filename)
 void FCEUI_LoadState(const char *fname, bool display_message)
 {
 	if(!FCEU_IsValidUI(FCEUI_LOADSTATE)) return;
+
+    if(!RA_WarnDisableHardcore("load a state")) return;
 
 	StateShow = 0;
 	loadStateFailed = 0;

--- a/RANes/src/state.cpp
+++ b/RANes/src/state.cpp
@@ -943,8 +943,6 @@ void FCEUI_SaveState(const char *fname, bool display_message)
 {
 	if(!FCEU_IsValidUI(FCEUI_SAVESTATE)) return;
 
-    if(!RA_WarnDisableHardcore("save a state")) return;
-
 	StateShow = 0;
 
 	FCEUSS_Save(fname, display_message);

--- a/RAProject64/Source/Project64-core/N64System/N64Class.cpp
+++ b/RAProject64/Source/Project64-core/N64System/N64Class.cpp
@@ -1665,6 +1665,9 @@ bool CN64System::SaveState()
     {
         SaveFile = ZipFile;
     }
+
+    RA_OnSaveState(SaveFile);
+
     g_Notify->DisplayMessage(5, stdstr_f("%s %s", g_Lang->GetString(MSG_SAVED_STATE).c_str(), stdstr(SaveFile.GetNameExtension()).c_str()).c_str());
     WriteTrace(TraceN64System, TraceDebug, "Done");
     return true;
@@ -1904,6 +1907,8 @@ bool CN64System::LoadState(const char * FileName)
             hExtraInfo.Close();
         }
     }
+
+    RA_OnLoadState(SaveFile);
 
     //Fix losing audio in certain games with certain plugins
     AudioResetOnLoad = g_Settings->LoadBool(Game_AudioResetOnLoad);

--- a/RAProject64/Source/Project64/Project64.vcxproj
+++ b/RAProject64/Source/Project64/Project64.vcxproj
@@ -29,9 +29,11 @@
   </PropertyGroup>
   <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <CharacterSet>MultiByte</CharacterSet>
+    <PlatformToolset>v141_xp</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <CharacterSet>MultiByte</CharacterSet>
+    <PlatformToolset>v141_xp</PlatformToolset>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <ImportGroup Label="PropertySheets">

--- a/RAProject64/Source/Project64/UserInterface/MainMenuClass.cpp
+++ b/RAProject64/Source/Project64/UserInterface/MainMenuClass.cpp
@@ -317,49 +317,36 @@ bool CMainMenu::ProcessMessage(HWND hWnd, DWORD /*FromAccelerator*/, DWORD MenuI
         }
         break;
     case ID_SYSTEM_SAVE:
-		if (RA_HardcoreModeIsActive())
-		{
-			if (MessageBox(NULL, "Hardcore mode is active. If you load/save a state, Hardcore Mode will be disabled. Continue?", "Warning", MB_YESNO) == IDNO)
-				break;
-			else {
-				RA_OnSaveState( NULL );
-			}
-		}
+        if (!RA_WarnDisableHardcore("save a state"))
+            break;
+
+		RA_OnSaveState( NULL );
+
         WriteTrace(TraceUserInterface, TraceDebug, "ID_SYSTEM_SAVE");
         g_BaseSystem->ExternalEvent(SysEvent_SaveMachineState);
         break;
-    case ID_SYSTEM_SAVEAS: 
-		if (RA_HardcoreModeIsActive())
-		{
-			if (MessageBox(NULL, "Hardcore mode is active. If you load/save a state, Hardcore Mode will be disabled. Continue?", "Warning", MB_YESNO) == IDNO)
-				break;
-			else {
-				RA_OnSaveState( NULL );
-			}
-		}
-		OnSaveAs(hWnd); 
+    case ID_SYSTEM_SAVEAS:
+        if (!RA_WarnDisableHardcore("save a state"))
+            break;
+
+		RA_OnSaveState( NULL );
+
+        OnSaveAs(hWnd); 
 		break;
     case ID_SYSTEM_RESTORE:
-		if (RA_HardcoreModeIsActive())
-		{
-			if (MessageBox(NULL, "Hardcore mode is active. If you load/save a state, Hardcore Mode will be disabled. Continue?", "Warning", MB_YESNO) == IDNO)
-				break;
-			else {
-				RA_OnSaveState( NULL );
-			}
-		}
+        if (!RA_WarnDisableHardcore("load a state"))
+            break;
+
+        RA_OnLoadState( NULL );
+
         WriteTrace(TraceUserInterface, TraceDebug, "ID_SYSTEM_RESTORE");
         g_BaseSystem->ExternalEvent(SysEvent_LoadMachineState);
         break;
-    case ID_SYSTEM_LOAD: 
-		if (RA_HardcoreModeIsActive())
-		{
-			if (MessageBox(NULL, "Hardcore mode is active. If you load/save a state, Hardcore Mode will be disabled. Continue?", "Warning", MB_YESNO) == IDNO)
-				break;
-			else {
-				RA_OnSaveState( NULL );
-			}
-		}
+    case ID_SYSTEM_LOAD:
+        if (!RA_WarnDisableHardcore("load a state"))
+            break;
+
+        RA_OnLoadState( NULL );
 		OnLodState(hWnd); 
 		break;
     case ID_SYSTEM_CHEAT: //OnCheats(hWnd); 
@@ -384,27 +371,15 @@ bool CMainMenu::ProcessMessage(HWND hWnd, DWORD /*FromAccelerator*/, DWORD MenuI
         }
         break;
     case ID_OPTIONS_INCREASE_SPEED:
-		if (RA_HardcoreModeIsActive())
-		{
-			if (MessageBox(NULL, "Hardcore mode is active. If you increase/decrease the speed of the game, Hardcore Mode will be disabled. Continue?", "Warning", MB_YESNO) == IDNO)
-				break;
-			else {
-				RA_OnSaveState( NULL );
-				break;
-			}
-		}
+        if (RA_HardcoreModeIsActive())
+            break;
+
         g_BaseSystem->AlterSpeed(CSpeedLimiter::INCREASE_SPEED);
         break;
     case ID_OPTIONS_DECREASE_SPEED:
-		if (RA_HardcoreModeIsActive())
-		{
-			if (MessageBox(NULL, "Hardcore mode is active. If you increase/decrease the speed of the game, Hardcore Mode will be disabled. Continue?", "Warning", MB_YESNO) == IDNO)
-				break;
-			else {
-				RA_OnSaveState( NULL );
-				break;
-			}
-		}
+        if (RA_HardcoreModeIsActive())
+            break;
+
         g_BaseSystem->AlterSpeed(CSpeedLimiter::DECREASE_SPEED);
         break;
     case ID_OPTIONS_FULLSCREEN:

--- a/RAProject64/Source/Project64/UserInterface/MainMenuClass.cpp
+++ b/RAProject64/Source/Project64/UserInterface/MainMenuClass.cpp
@@ -317,27 +317,15 @@ bool CMainMenu::ProcessMessage(HWND hWnd, DWORD /*FromAccelerator*/, DWORD MenuI
         }
         break;
     case ID_SYSTEM_SAVE:
-        if (!RA_WarnDisableHardcore("save a state"))
-            break;
-
-		RA_OnSaveState( NULL );
-
         WriteTrace(TraceUserInterface, TraceDebug, "ID_SYSTEM_SAVE");
         g_BaseSystem->ExternalEvent(SysEvent_SaveMachineState);
         break;
     case ID_SYSTEM_SAVEAS:
-        if (!RA_WarnDisableHardcore("save a state"))
-            break;
-
-		RA_OnSaveState( NULL );
-
         OnSaveAs(hWnd); 
 		break;
     case ID_SYSTEM_RESTORE:
         if (!RA_WarnDisableHardcore("load a state"))
             break;
-
-        RA_OnLoadState( NULL );
 
         WriteTrace(TraceUserInterface, TraceDebug, "ID_SYSTEM_RESTORE");
         g_BaseSystem->ExternalEvent(SysEvent_LoadMachineState);
@@ -346,7 +334,6 @@ bool CMainMenu::ProcessMessage(HWND hWnd, DWORD /*FromAccelerator*/, DWORD MenuI
         if (!RA_WarnDisableHardcore("load a state"))
             break;
 
-        RA_OnLoadState( NULL );
 		OnLodState(hWnd); 
 		break;
     case ID_SYSTEM_CHEAT: //OnCheats(hWnd); 

--- a/RASnes9x/memmap.cpp
+++ b/RASnes9x/memmap.cpp
@@ -2077,13 +2077,6 @@ void CMemory::ClearSRAM (bool8 onlyNonSavedSRAM)
 
 bool8 CMemory::LoadSRAM (const char *filename)
 {
-	//	Must allow SRAM in hardcore, surely?!
-	//if( RA_HardcoreModeIsActive() )
-	//{
-	//	if( MessageBox( NULL, "Hardcore mode is active. If you load/save a state, Hardcore Mode will be disabled. Continue?", "Warning", MB_YESNO ) == IDNO )
-	//		return (FALSE);
-	//}
-
 	FILE	*file;
 	int		size, len;
 	char	sramName[PATH_MAX + 1];
@@ -2174,13 +2167,6 @@ bool8 CMemory::SaveSRAM (const char *filename)
 
 	if (Settings.SA1 && ROMType == 0x34)    // doesn't have SRAM
 		return (TRUE);
-
-	//	Must allow SRAM in hardcore, surely?!
-	//if( RA_HardcoreModeIsActive() )
-	//{
-	//	if( MessageBox( NULL, "Hardcore mode is active. If you load/save a state, Hardcore Mode will be disabled. Continue?", "Warning", MB_YESNO ) == IDNO )
-	//		return false;
-	//}
 
 	FILE	*file;
 	int		size;

--- a/RASnes9x/win32/wsnes9x.cpp
+++ b/RASnes9x/win32/wsnes9x.cpp
@@ -1290,7 +1290,7 @@ int HandleKeyMessage(WPARAM wParam, LPARAM lParam)
         if(wParam == CustomKeys.Rewind.key
 		&& modifiers == CustomKeys.Rewind.modifiers)
 		{
-            if (RA_WarnDisableHardcore("rewind"))
+            if (!RA_HardcoreModeIsActive())
                 return 1;
 
             if(!GUI.rewinding)

--- a/RASnes9x/win32/wsnes9x.cpp
+++ b/RASnes9x/win32/wsnes9x.cpp
@@ -3740,7 +3740,7 @@ loop_exit:
 
 void FreezeUnfreeze (int slot, bool8 freeze)
 {
-    if(!RA_WarnDisableHardcore(freeze ? "save a state" : "load a state"))
+    if(!freeze && !RA_WarnDisableHardcore("load a state"))
         return;
 
 #ifdef NETPLAY_SUPPORT

--- a/RASnes9x/win32/wsnes9x.cpp
+++ b/RASnes9x/win32/wsnes9x.cpp
@@ -1182,10 +1182,10 @@ int HandleKeyMessage(WPARAM wParam, LPARAM lParam)
 		if(wParam == CustomKeys.SpeedDown.key
 		&& modifiers == CustomKeys.SpeedDown.modifiers)
 		{
-			if (RA_HardcoreModeIsActive())
-				return 1;
+            if (RA_HardcoreModeIsActive())
+                return 1;
 
-			// Increase emulated frame time
+            // Increase emulated frame time
 			int i;
 			for(i=1; FrameTimings[i]<Settings.FrameTime; ++i)
 				;
@@ -1200,8 +1200,8 @@ int HandleKeyMessage(WPARAM wParam, LPARAM lParam)
 		if(wParam == CustomKeys.SpeedUp.key
 		&& modifiers == CustomKeys.SpeedUp.modifiers)
 		{
-			if (RA_HardcoreModeIsActive())
-				return 1;
+            if (RA_HardcoreModeIsActive())
+                return 1;
 
 			// Decrease emulated frame time
 			int i;
@@ -1290,14 +1290,8 @@ int HandleKeyMessage(WPARAM wParam, LPARAM lParam)
         if(wParam == CustomKeys.Rewind.key
 		&& modifiers == CustomKeys.Rewind.modifiers)
 		{
-			if (RA_HardcoreModeIsActive())
-			{
-				MessageBox(nullptr,
-					_T("Hardcore Mode is active. Rewind key is disabled."),
-					_T("Warning"),
-					MB_OK);
-				return 1;
-			}
+            if (RA_WarnDisableHardcore("rewind"))
+                return 1;
 
             if(!GUI.rewinding)
                 S9xMessage (S9X_INFO, 0, GUI.rewindBufferSize?WINPROC_REWINDING_TEXT:WINPROC_REWINDING_DISABLED);
@@ -1701,14 +1695,8 @@ LRESULT CALLBACK WinProc(
 			break;
 		case ID_FILE_MOVIE_PLAY:
 			{
-			if (RA_HardcoreModeIsActive())
-			{
-				MessageBox(nullptr,
-					+_T("Hardcore Mode is active. Movie Recording/Playback is disabled."),
-					+_T("Warning"),
-					+MB_OK);
-				break;
-			}
+                if(!RA_WarnDisableHardcore("playback a recording"))
+                    return 1;
 
 				RestoreGUIDisplay ();  //exit DirectX
 				OpenMovieParams op;
@@ -1740,14 +1728,8 @@ LRESULT CALLBACK WinProc(
 			break;
 		case ID_FILE_MOVIE_RECORD:
 			{
-			if (RA_HardcoreModeIsActive())
-			{
-				MessageBox(nullptr,
-					+_T("Hardcore Mode is active. Movie Recording/Playback is disabled."),
-					+_T("Warning"),
-					+MB_OK);
-				break;
-			}
+                if(!RA_WarnDisableHardcore("record a movie"))
+                    return 1;
 
 				RestoreGUIDisplay ();  //exit DirectX
 				OpenMovieParams op;
@@ -3758,14 +3740,8 @@ loop_exit:
 
 void FreezeUnfreeze (int slot, bool8 freeze)
 {
-	if( RA_HardcoreModeIsActive() )
-	{
-		if( MessageBox( nullptr,
-						_T( "Hardcore mode is active. If you load/save a state, Hardcore Mode will be disabled. Continue?" ),
-						_T( "Warning" ),
-						MB_YESNO ) == IDNO )
-			return;
-	}
+    if(!RA_WarnDisableHardcore(freeze ? "save a state" : "load a state"))
+        return;
 
 #ifdef NETPLAY_SUPPORT
     if (!freeze && Settings.NetPlay && !Settings.NetPlayServer)

--- a/RAVBA-M/src/win32/MainWnd.cpp
+++ b/RAVBA-M/src/win32/MainWnd.cpp
@@ -1070,12 +1070,8 @@ CString MainWnd::winLoadFilter(UINT id)
 
 bool MainWnd::loadSaveGame(const char *name)
 {
-	if( RA_HardcoreModeIsActive() )
-	{
-		if( ::MessageBox( theApp.GetMainWnd()->GetSafeHwnd(),
-			"Hardcore mode is active. If you load a state, you will disable Hardcore Mode. Continue?", "Warning", MB_YESNO ) == IDNO )
-			return false;
-	}
+    if (!RA_WarnDisableHardcore("load a state"))
+        return false;
 
 	if(theApp.emulator.emuReadState)
 	{	
@@ -1091,12 +1087,8 @@ bool MainWnd::loadSaveGame(const char *name)
 
 bool MainWnd::writeSaveGame(const char *name)
 {
-	if( RA_HardcoreModeIsActive() )
-	{
-		if( ::MessageBox( theApp.GetMainWnd()->GetSafeHwnd(),
-			"Hardcore mode is active. If you save a state, you will disable Hardcore Mode. Continue?", "Warning", MB_YESNO ) == IDNO )
-			return false;
-	}
+    if (!RA_WarnDisableHardcore("save a state"))
+        return false;
 
 	if(theApp.emulator.emuWriteState)
 	{

--- a/RAVBA-M/src/win32/MainWnd.cpp
+++ b/RAVBA-M/src/win32/MainWnd.cpp
@@ -1087,9 +1087,6 @@ bool MainWnd::loadSaveGame(const char *name)
 
 bool MainWnd::writeSaveGame(const char *name)
 {
-    if (!RA_WarnDisableHardcore("save a state"))
-        return false;
-
 	if(theApp.emulator.emuWriteState)
 	{
 		bool bSaveOK = theApp.emulator.emuWriteState(name);

--- a/RAVBA-M/src/win32/MainWndFile.cpp
+++ b/RAVBA-M/src/win32/MainWndFile.cpp
@@ -261,7 +261,8 @@ BOOL MainWnd::OnFileLoadSlot(UINT nID)
   if (theApp.paused)
     InterframeCleanup();
 
-  systemScreenMessage(buffer);
+  if (res)
+      systemScreenMessage(buffer);
 
   systemDrawScreen();
 
@@ -357,12 +358,12 @@ BOOL MainWnd::OnFileSaveSlot(UINT nID)
     filename.Format("%s\\%s%d.sgm", saveDir, buffer, nID);
 
   bool res = writeSaveGame(filename);
+  if (res) {
+      CString format = winResLoadString(IDS_WROTE_STATE_N);
+      buffer.Format(format, nID);
 
-  CString format = winResLoadString(IDS_WROTE_STATE_N);
-  buffer.Format(format, nID);
-
-  systemScreenMessage(buffer);
-
+      systemScreenMessage(buffer);
+  }
   systemDrawScreen();
 
   return res;

--- a/RAVBA-M/src/win32/MainWndFile.cpp
+++ b/RAVBA-M/src/win32/MainWndFile.cpp
@@ -156,7 +156,7 @@ void MainWnd::OnFileClose()
   }
   emulating = 0;
   RedrawWindow(NULL,NULL,RDW_INVALIDATE|RDW_ERASE|RDW_ALLCHILDREN);
-  systemSetTitle(VBA_NAME_AND_SUBVERSION);
+  systemSetTitle("");
 }
 
 void MainWnd::OnUpdateFileClose(CCmdUI* pCmdUI)

--- a/RAVBA-M/src/win32/MainWndOptions.cpp
+++ b/RAVBA-M/src/win32/MainWndOptions.cpp
@@ -674,7 +674,7 @@ BOOL MainWnd::OnOptionsEmulatorShowSpeed(UINT nID)
   switch(nID) {
   case ID_OPTIONS_EMULATOR_SHOWSPEED_NONE:
     theApp.showSpeed = 0;
-    systemSetTitle(VBA_NAME_AND_SUBVERSION);
+    systemSetTitle("");
     break;
   case ID_OPTIONS_EMULATOR_SHOWSPEED_PERCENTAGE:
     theApp.showSpeed = 1;

--- a/RAVBA-M/src/win32/VBA.cpp
+++ b/RAVBA-M/src/win32/VBA.cpp
@@ -1070,9 +1070,9 @@ void systemShowSpeed(int speed)
   if(theApp.videoOption <= VIDEO_6X && theApp.showSpeed) {
     CString buffer;
     if(theApp.showSpeed == 1)
-      buffer.Format(VBA_NAME_AND_SUBVERSION "-%3d%%", systemSpeed);
+      buffer.Format("%3d%%", systemSpeed);
     else
-      buffer.Format(VBA_NAME_AND_SUBVERSION "-%3d%%(%d, %d fps)", systemSpeed,
+      buffer.Format("%3d%%(%d, %d fps)", systemSpeed,
                     systemFrameSkip,
                     theApp.showRenderedFrames);
 


### PR DESCRIPTION
Replaces individual calls that prompt the user to disable hardcore mode with a function in `RA_Interface`.  The function will call into the toolkit (via https://github.com/RetroAchievements/RAIntegration/pull/90) to actually disable hardcore mode. Previously, relied on the `RA_OnSaveState` and `RA_OnLoadState` functions called after the dialog was shown for disabling hardcore mode. Those functions still do the check and enforce the requirement in case the user is on an older version of the emulator.

* Removed "not allowed" dialog from RAGens->Rewind and RASnes9x->Rewind. Pressing the associated buttons will simply not do anything.
* Removed warning from RAProject64->Change speed. Pressing the associated buttons will simply not do anything.

* Fixed double warning when attempting to load a state in hardcore mode in RANes
* Fixed writing "loaded state"/"saved state" message to screen in RAVBA-M when declining to switch to non-hardcore mode.
