### PR TITLE
don't call RA_DoAchievementsFrame when RANes is paused

### DIFF
--- a/RANes/src/drivers/win/main.cpp
+++ b/RANes/src/drivers/win/main.cpp
@@ -861,9 +861,8 @@ doloopy:
 				skippy = 0;
 			}
 
-			//##RA
-			RA_DoAchievementsFrame();
-			RA_HandleHTTPResults();
+            //##RA
+            RA_HandleHTTPResults();
 
 			FCEUI_Emulate(&gfx, &sound, &ssize, skippy); //emulate a single frame
 			FCEUD_Update(gfx, sound, ssize); //update displays and debug tools

--- a/RANes/src/fceu.cpp
+++ b/RANes/src/fceu.cpp
@@ -700,6 +700,9 @@ void FCEUI_Emulate(uint8 **pXBuf, int32 **SoundBuf, int32 *SoundBufSize, int ski
 	CallRegisteredLuaFunctions(LUACALL_AFTEREMULATION);
 #endif
 
+    //##RA
+    RA_DoAchievementsFrame();
+
 #ifdef WIN32
 	//These Windows only dialogs need to be updated only once per frame so they are included here
 	UpdateCheatList(); // CaH4e3: can't see why, this is only cause problems with selection - adelikat: selection is only a problem when not paused, it shoudl be paused to select, we want to see the values update


### PR DESCRIPTION
Fixes https://github.com/RetroAchievements/RAIntegration/issues/159

Note: this causes achievement processing to be called after the emulator updates the current frame, instead of just before it updates the next frame. This is consistent with RASnes9x and RAVBA-M (possibly the others - I only checked those two). I don't expect it to cause any issues.