### PR TITLE
ignore header when generating SNES hash

### DIFF
--- a/RASnes9x/loadzip.cpp
+++ b/RASnes9x/loadzip.cpp
@@ -273,10 +273,6 @@ bool8 LoadZip (const char *zipname, uint32 *TotalFileSize, uint8 *buffer)
 			return (FALSE);
 		}
 
-		//	GRAB IT! ##RA
-		memcpy(Memory.ROMUntouched, ptr, FileSize);
-		Memory.FileSizeBytes = FileSize;
-
 		FileSize = Memory.HeaderRemove(FileSize, ptr);
 		ptr += FileSize;
 		*TotalFileSize += FileSize;

--- a/RASnes9x/memmap.cpp
+++ b/RASnes9x/memmap.cpp
@@ -1067,7 +1067,6 @@ bool8 CMemory::Init (void)
     SRAM = (uint8 *) malloc(0x20000);
     VRAM = (uint8 *) malloc(0x10000);
     ROM			  = (uint8 *) malloc(MAX_ROM_SIZE + 0x200 + 0x8000);
-    ROMUntouched  = (uint8 *) malloc(MAX_ROM_SIZE + 0x200 + 0x8000);
 
 	IPPU.TileCache[TILE_2BIT]       = (uint8 *) malloc(MAX_2BIT_TILES * 64);
 	IPPU.TileCache[TILE_4BIT]       = (uint8 *) malloc(MAX_4BIT_TILES * 64);
@@ -1109,7 +1108,6 @@ bool8 CMemory::Init (void)
 	memset(SRAM, 0, 0x20000);
 	memset(VRAM, 0, 0x10000);
 	memset(ROM,			 0,  MAX_ROM_SIZE + 0x200 + 0x8000);
-	memset(ROMUntouched, 0,  MAX_ROM_SIZE + 0x200 + 0x8000);
 
 	memset(IPPU.TileCache[TILE_2BIT], 0,       MAX_2BIT_TILES * 64);
 	memset(IPPU.TileCache[TILE_4BIT], 0,       MAX_4BIT_TILES * 64);
@@ -1178,12 +1176,6 @@ void CMemory::Deinit (void)
 		ROM -= 0x8000;
 		free(ROM);
 		ROM = NULL;
-	}
-
-	if (ROMUntouched)
-	{
-		free(ROMUntouched);
-		ROMUntouched = NULL;
 	}
 
 	for (int t = 0; t < 7; t++)
@@ -1450,10 +1442,6 @@ uint32 CMemory::FileLoader (uint8 *buffer, const char *filename, uint32 maxsize)
 				return (0);
 			}
 
-			//	##RA GRAB IT!
-			memcpy(Memory.ROMUntouched, buffer, size);
-			Memory.FileSizeBytes = totalSize;
-
 			//	##RA this doesn't look right: totalsize should be the ACTUAL file size
 			//totalSize = HeaderRemove(size, buffer);
 			totalSize = size;
@@ -1485,10 +1473,6 @@ uint32 CMemory::FileLoader (uint8 *buffer, const char *filename, uint32 maxsize)
 			{
 				size = READ_STREAM(ptr, maxsize + 0x200 - (ptr - buffer), fp);
 				CLOSE_STREAM(fp);
-
-				//	##RA GRAB IT!
-				memcpy(Memory.ROMUntouched, ptr, size);
-				Memory.FileSizeBytes = size;
 
 				size = HeaderRemove(size, ptr);
 				totalSize += size;

--- a/RASnes9x/memmap.h
+++ b/RASnes9x/memmap.h
@@ -236,8 +236,6 @@ struct CMemory
 	uint8	*BSRAM;
 	uint8	*BIOSROM;
 
-	uint8	*ROMUntouched;
-
 	uint8	*Map[MEMMAP_NUM_BLOCKS];
 	uint8	*WriteMap[MEMMAP_NUM_BLOCKS];
 	uint8	BlockIsRAM[MEMMAP_NUM_BLOCKS];
@@ -257,7 +255,6 @@ struct CMemory
 	uint32	ROMComplementChecksum;
 	uint32	ROMCRC32;
 	int32	ROMFramesPerSecond;
-	uint32	FileSizeBytes;
 
 	bool8	HiROM;
 	bool8	LoROM;

--- a/RASnes9x/win32/wsnes9x.cpp
+++ b/RASnes9x/win32/wsnes9x.cpp
@@ -4138,7 +4138,7 @@ static bool LoadROMPlain(const TCHAR *filename)
 		RA_InstallMemoryBank( 0, ByteReader, ByteWriter, 0x20000 );
 		RA_InstallMemoryBank( 1, ByteReaderSRAM, ByteWriterSRAM, nSRAMBytes );
 
-		RA_OnLoadNewRom(Memory.ROMUntouched, Memory.FileSizeBytes);
+		RA_OnLoadNewRom(Memory.ROM, Memory.CalculatedSize);
 
 		S9xStartCheatSearch (&Cheat);
         ReInitSound();


### PR DESCRIPTION
Ensures both headered and non-headered ROMs generate the same hash. Headered ROMs are typically required when applying ips files (translation patches).