### PR TITLE
support major.minor.patch version tags for RAQUASI88

### DIFF
--- a/RAQUASI88/visualc/MakeBuildVer.bat
+++ b/RAQUASI88/visualc/MakeBuildVer.bat
@@ -35,5 +35,5 @@ del ..\src\WIN32\BuildVer.h
 move BuildVer2.h ..\src\WIN32\BuildVer.h > nul
 :done
 
-rem === Clean up after ourself ===
+rem === Clean up after ourselves ===
 del Temp.txt

--- a/RAQUASI88/visualc/MakeBuildVer.bat
+++ b/RAQUASI88/visualc/MakeBuildVer.bat
@@ -1,25 +1,29 @@
 @echo off
 
+rem === Get the most recent tag matching our prefix ===
 git describe --tags --match "RAQUASI88.*" > Temp.txt
 set /p ACTIVE_TAG=<Temp.txt
-set VERSION_TAG=%ACTIVE_TAG:~10%
-for /f "tokens=1,2 delims=-" %%a in ("%VERSION_TAG%") do set VERSION_NUM=%%a&set VERSION_REVISION=%%b
+for /f "tokens=1,2 delims=-" %%a in ("%ACTIVE_TAG:~10%") do set VERSION_TAG=%%a&set VERSION_REVISION=%%b
 if "%VERSION_REVISION%" == "" set VERSION_REVISION=0
 
+rem === Extract the major/minor/patch version from the tag (append 0s if necessary) ===
+for /f "tokens=1,2,3 delims=." %%a in ("%VERSION_TAG%.0.0") do set VERSION_NUM=%%a.%%b.%%c
+
+rem === If there are any local modifications, increment revision ===
 setlocal
 git diff HEAD > Temp.txt
 for /F "usebackq" %%A in ('"Temp.txt"') do set DIFF_FILE_SIZE=%%~zA
 if %DIFF_FILE_SIZE% GTR 0 (
     set ACTIVE_TAG=Unstaged changes
-    set VERSION_MODIFIED=1
-) else (
-    set VERSION_MODIFIED=0
+    set /A VERSION_REVISION=VERSION_REVISION+1
 )
 
-@echo Tag: %ACTIVE_TAG% (%VERSION_NUM%)
-@echo #define RAQUASI88_VERSION "%VERSION_NUM%.%VERSION_REVISION%.%VERSION_MODIFIED%" > BuildVer2.h
-@echo #define RAQUASI88_VERSION_SHORT "%VERSION_NUM%" >> BuildVer2.h
+rem === Generate a new version file ===
+@echo Tag: %ACTIVE_TAG% (%VERSION_TAG%)
+@echo #define RAQUASI88_VERSION "%VERSION_NUM%.%VERSION_REVISION%" > BuildVer2.h
+@echo #define RAQUASI88_VERSION_SHORT "%VERSION_TAG%" >> BuildVer2.h
 
+rem === Update the existing file only if the new file differs ===
 if not exist ..\src\WIN32\BuildVer.h goto nonexistant
 fc ..\src\WIN32\BuildVer.h BuildVer2.h > nul
 if errorlevel 1 goto different
@@ -31,4 +35,5 @@ del ..\src\WIN32\BuildVer.h
 move BuildVer2.h ..\src\WIN32\BuildVer.h > nul
 :done
 
+rem === Clean up after ourself ===
 del Temp.txt


### PR DESCRIPTION
* Changes the version format from MAJOR.MINOR.COMMITS.LOCALMODIFICATIONS to MAJOR.MINOR.PATCH.COMMITS+LOCALMODIFICATIONS.
* Effectively treats local modifications as an additional commit. Allows three digits for official releases and one digit for custom builds.
* I plan to apply these changes to the toolkit and other emulators on each of their next releases.