### PR TITLE
Update RAQUASI88 to ver 1.1.3 (QUASI88kai ver 0.6.8)

### DIFF
--- a/RAQUASI88/README.md
+++ b/RAQUASI88/README.md
@@ -9,17 +9,20 @@ The aim is to fix bugs and implement new features with minimal changes to the so
 主な更新内容 / Main changes:
 * ビルドシステムの一般更新・修正（現在のコンパイラをサポートするように） / General updates to the build system (to support modern compilers)
 * 全ファイルをUTF-8に変換 / All files converted to UTF-8
-* Win32版に -double を実装 / Support -double in the Win32 version
+* Win32版に -double、-fullscreen を実装 / Support -double and -fullscreen in the Win32 version
+* Win32版に起動オプションを有効にする / Support launch options in the Win32 version
 * Win32版にテープのイメージファイルのドラッグ・アンド・ドロップを実装 / Support drag-and-drop of tape image files in the Win32 version
+* フォーカスが外される時はキーの押下状態を解除 / Clear key press state when losing focus
+* 偽メモリウェイト使用時の音出力を修正 / Fix audio output when using memory wait
 * RetroAchievements対応版「RAQUASI88」を追加 / Add a RetroAchievements-compatible version "RAQUASI88"
 
 この先の予定についてはイッシューページの enhancement タグを参照してください。
 
 Please refer to issues with the "enhancement" tag for future plans.
 
-最新バージョンは、 0.6.6　(2019/01/07 リリース) です。
+最新バージョンは、 0.6.8　(2019/02/14 リリース) です。
 
-The latest version is 0.6.6 (released 2019/01/07).
+The latest version is 0.6.8 (released 2019/02/14).
 
 ---
 

--- a/RAQUASI88/document/HISTORY.TXT
+++ b/RAQUASI88/document/HISTORY.TXT
@@ -1,12 +1,30 @@
 
 
-            QUASI88改の履歴
+            QUASI88kai Changelog / QUASI88改の履歴
+
+
+2019/02/14 ver 0.6.8
+    New (新機能):
+        Support launch options in the Win32 version (Win32版に起動オプションを有効にする)
+    Other changes (他更新内容):
+        Clear key press state when losing focus (フォーカスが外される時はキーの押下状態を解除)
+        Various fixes to RAQUASI88 and the Win32 full screen mode (RAQUASI88、Win32版のフルスクリーンモードを色々修正)
+
+
+2019/02/10 ver 0.6.7
+    New (新機能):
+        Improve memory wait emulation and fix BEEP audio output with -v1s -mem_wait (メモリウェイトを改良し、 -v1s -mem_wait でのBEEP音出力を修正)
+        Implement integer scale -fullscreen on Win32 (Win32版に -fullscreen を実装)
+
+    Other changes (他更新内容):
+        Move the disk save folder to SAVE (ディスクセーブのフォルダを SAVE へ移動)
 
 
 2019/01/07 ver 0.6.6
     New (新機能):
         Tape image drag-and-drop support on Win32 (Win32版にテープのイメージファイルのドラッグ・アンド・ドロップを実装)
         Add a RetroAchievements-compatible version "RAQUASI88" ver 1.0.0 (RetroAchievements対応版「RAQUASI88」 ver 1.0.0 を追加)
+        Implement disk save: loaded disks are copied into the DISK folder, and files with names corresponding to loaded images are read and written from there in order to preserve the originals (ディスクセーブを実装 → DISK フォルダにディスクイメージをコピーし、そのフォルダから挿入されるイメージと同じファイル名のコピーを読み書きすることで元ファイルを上書きせずに保持る)
     Other changes (他更新内容):
         Rename the project to QUASI88改 (名称を「QUASI88改」へ変更)
         Translate some documents into English (幾つかの文書の英語訳を追加)
@@ -14,7 +32,7 @@
 
 2018/12/24 ver 0.6.5
     New (新機能):
-        Double window size support in win32 (win32版に倍のウィンドウサイズをサポート)
+        Double window size support in Win32 (Win32版に倍のウィンドウサイズをサポート)
         UTF-8 support on Windows (Windows版にUTF-8をサポート)
     Other changes (他更新内容):
         All files converted to UTF-8 (全ファイルをUTF-8に変換)

--- a/RAQUASI88/src/FWIN/file-op.c
+++ b/RAQUASI88/src/FWIN/file-op.c
@@ -269,7 +269,7 @@ OSD_FILE *osd_fopen(int type, const char *path, const char *mode)
     fullname = _fullpath(NULL, path, 0);    /* ファイル名を取得する */
     if (fullname == NULL) return NULL;
 
-    if ((type == FTYPE_DISK) && osd_file_stat(fullname))
+    if (type == FTYPE_DISK && !strcmp("r+b", mode) && osd_file_stat(fullname))
     {
         localname = calloc(_MAX_PATH, sizeof(char));
         osd_file_localname(fullname, localname);

--- a/RAQUASI88/src/WIN32/main.cpp
+++ b/RAQUASI88/src/WIN32/main.cpp
@@ -70,8 +70,12 @@ int WINAPI WinMain(HINSTANCE hInst,
     /* 一部の初期値を改変 (いいやり方はないかな…) */
     romaji_type = 1;            /* ローマ字変換の規則を MS-IME風に */
 
+#ifndef __argc
+#define __argc 0
+#define __argv NULL
+#endif
 
-    if (config_init(0, NULL,        /* 環境初期化 & 引数処理 */
+    if (config_init(__argc, __argv,        /* 環境初期化 & 引数処理 */
             NULL,
             NULL)) {
 

--- a/RAQUASI88/src/WIN32/menubar.cpp
+++ b/RAQUASI88/src/WIN32/menubar.cpp
@@ -461,6 +461,11 @@ static void menubar_item_setup(void)
     CheckMenuRadioItem(g_hMenu, M_SET_SIZ_FULL, M_SET_SIZ_DOUBLE, uItem,
                MF_BYCOMMAND);
 
+    i = quasi88_cfg_now_fullscreen();   /* ＊＊＊＊ */
+    uItem = M_SET_FULLSCREEN;
+    CheckMenuItem(g_hMenu, uItem,
+        MF_BYCOMMAND | (i ? MFS_CHECKED : MFS_UNCHECKED));
+
     i = use_pcg;                        /* ＊＊＊＊ */
     uItem = M_SET_PCG;
     CheckMenuItem(g_hMenu, uItem,
@@ -648,6 +653,7 @@ static  void    f_set_fdcwait   (UINT uItem);
 static  void    f_set_refresh   (UINT uItem, int data);
 static  void    f_set_interlace (UINT uItem, int data);
 static  void    f_set_size  (UINT uItem, int data);
+static  void    f_set_fullscreen   (UINT uItem);
 static  void    f_set_pcg   (UINT uItem);
 static  void    f_set_mouse (UINT uItem, int data);
 static  void    f_set_cursor    (UINT uItem, int data);
@@ -730,7 +736,9 @@ int menubar_event(int id)
     case M_SET_SIZ_DOUBLE:  f_set_size(id, SCREEN_SIZE_DOUBLE); break;
 #endif
 
-    case M_SET_PCG:     f_set_pcg(id);          break;
+    case M_SET_FULLSCREEN:  f_set_fullscreen(id);   break;
+
+    case M_SET_PCG:         f_set_pcg(id);          break;
 
     case M_SET_MO_NO:       f_set_mouse(id, MOUSE_NONE);        break;
     case M_SET_MO_MOUSE:    f_set_mouse(id, MOUSE_MOUSE);       break;
@@ -1002,6 +1010,29 @@ static  void    f_set_size(UINT uItem, int data)
     {
     quasi88_cfg_set_size((int)data);
     }
+
+    /*if (data > SCREEN_SIZE_FULL && quasi88_cfg_now_fullscreen()) {
+        f_set_fullscreen(M_SET_FULLSCREEN);
+    }*/
+}
+
+static  void    f_set_fullscreen(UINT uItem)
+{
+    int active;
+    UINT res;
+
+    if (menubar_active == FALSE) { return; }
+
+    res = GetMenuState(g_hMenu, uItem, MF_BYCOMMAND);
+    active = (res & MFS_CHECKED) ? FALSE : TRUE;    /* 逆にする */
+    CheckMenuItem(g_hMenu, uItem,
+        MF_BYCOMMAND | (active ? MFS_CHECKED : MFS_UNCHECKED));
+
+    quasi88_cfg_set_fullscreen(active);
+
+    /*if (active && quasi88_cfg_now_size() > SCREEN_SIZE_FULL) {
+        f_set_size(M_SET_SIZ_FULL, SCREEN_SIZE_FULL);
+    }*/
 }
 
 static  void    f_set_pcg(UINT uItem)

--- a/RAQUASI88/src/WIN32/quasi88.rc
+++ b/RAQUASI88/src/WIN32/quasi88.rc
@@ -1,190 +1,192 @@
 #include "resource.h"
 
 QUASI88 MENU {
-	POPUP "System" {
-		MENUITEM "Reset",			M_SYS_RESET
+    POPUP "System" {
+        MENUITEM "Reset",               M_SYS_RESET
 
-		POPUP "Mode" {
-			MENUITEM "V2",			M_SYS_MODE_V2
-			MENUITEM "V1H",			M_SYS_MODE_V1H
-			MENUITEM "V1S",			M_SYS_MODE_V1S
-			MENUITEM "N",			M_SYS_MODE_N
-			MENUITEM SEPARATOR
-			MENUITEM "4MHz",		M_SYS_MODE_4MH
-			MENUITEM "8MHz",		M_SYS_MODE_8MH
-			MENUITEM SEPARATOR
-			MENUITEM "Sound Board",		M_SYS_MODE_SB
-			MENUITEM "Sound Board II",	M_SYS_MODE_SB2
-		}
+        POPUP "Mode" {
+            MENUITEM "V2",              M_SYS_MODE_V2
+            MENUITEM "V1H",             M_SYS_MODE_V1H
+            MENUITEM "V1S",             M_SYS_MODE_V1S
+            MENUITEM "N",               M_SYS_MODE_N
+            MENUITEM SEPARATOR
+            MENUITEM "4MHz",            M_SYS_MODE_4MH
+            MENUITEM "8MHz",            M_SYS_MODE_8MH
+            MENUITEM SEPARATOR
+            MENUITEM "Sound Board",     M_SYS_MODE_SB
+            MENUITEM "Sound Board II",  M_SYS_MODE_SB2
+        }
 
-		MENUITEM SEPARATOR
+        MENUITEM SEPARATOR
 
-		MENUITEM "V2  mode",			M_SYS_RESET_V2
-		MENUITEM "V1H mode",			M_SYS_RESET_V1H
-		MENUITEM "V1S mode",			M_SYS_RESET_V1S
+        MENUITEM "V2  mode",            M_SYS_RESET_V2
+        MENUITEM "V1H mode",            M_SYS_RESET_V1H
+        MENUITEM "V1S mode",            M_SYS_RESET_V1S
 
-		MENUITEM SEPARATOR
+        MENUITEM SEPARATOR
 
-		MENUITEM "Menu",			M_SYS_MENU
+        MENUITEM "Menu",                M_SYS_MENU
 
-		MENUITEM SEPARATOR
+        MENUITEM SEPARATOR
 
-		MENUITEM "Save Config",			M_SYS_SAVE
-		MENUITEM "Exit",			M_SYS_EXIT
-	}
+        MENUITEM "Save Config",         M_SYS_SAVE
+        MENUITEM "Exit",                M_SYS_EXIT
+    }
 
-	POPUP "Setting" {
-		POPUP "Speed" {
-			MENUITEM " 25%",		M_SET_SPD_25
-			MENUITEM " 50%",		M_SET_SPD_50
-			MENUITEM "100%",		M_SET_SPD_100
-			MENUITEM "200%",		M_SET_SPD_200
-			MENUITEM "400%",		M_SET_SPD_400
-			MENUITEM SEPARATOR
-			MENUITEM "No wait",		M_SET_SPD_MAX
-		}
+    POPUP "Setting" {
+        POPUP "Speed" {
+            MENUITEM " 25%",            M_SET_SPD_25
+            MENUITEM " 50%",            M_SET_SPD_50
+            MENUITEM "100%",            M_SET_SPD_100
+            MENUITEM "200%",            M_SET_SPD_200
+            MENUITEM "400%",            M_SET_SPD_400
+            MENUITEM SEPARATOR
+            MENUITEM "No wait",         M_SET_SPD_MAX
+        }
 
-		POPUP "Sub-CPU" {
-			MENUITEM "Run sometimes",	M_SET_SUB_SOME
-			MENUITEM "Run often",		M_SET_SUB_OFT
-			MENUITEM "Run always",		M_SET_SUB_ALL
-		}
+        POPUP "Sub-CPU" {
+            MENUITEM "Run sometimes",   M_SET_SUB_SOME
+            MENUITEM "Run often",       M_SET_SUB_OFT
+            MENUITEM "Run always",      M_SET_SUB_ALL
+        }
 
-		MENUITEM "Use FDC-Wait",		M_SET_FDCWAIT
+        MENUITEM "Use FDC-Wait",        M_SET_FDCWAIT
 
-		MENUITEM SEPARATOR
+        MENUITEM SEPARATOR
 
-		POPUP "Refresh Rate" {
-			MENUITEM "60fps",		M_SET_REF_60
-			MENUITEM "30fps",		M_SET_REF_30
-			MENUITEM "20fps",		M_SET_REF_20
-			MENUITEM "15fps",		M_SET_REF_15
-		}
+        POPUP "Refresh Rate" {
+            MENUITEM "60fps",           M_SET_REF_60
+            MENUITEM "30fps",           M_SET_REF_30
+            MENUITEM "20fps",           M_SET_REF_20
+            MENUITEM "15fps",           M_SET_REF_15
+        }
 
-		POPUP "Interlace" {
-			MENUITEM "No Interlace",	M_SET_INT_NO
-			MENUITEM "Skip Line",		M_SET_INT_SKIP
-			MENUITEM "Interlace",		M_SET_INT_YES
-		}
+        POPUP "Interlace" {
+            MENUITEM "No Interlace",    M_SET_INT_NO
+            MENUITEM "Skip Line",       M_SET_INT_SKIP
+            MENUITEM "Interlace",       M_SET_INT_YES
+        }
 
-		POPUP "Screen Size" {
-			MENUITEM "Normal size",		M_SET_SIZ_FULL
-			MENUITEM "Half size",		M_SET_SIZ_HALF
-#ifdef	SUPPORT_DOUBLE
-			MENUITEM "Double size",		M_SET_SIZ_DOUBLE
+        POPUP "Screen Size" {
+            MENUITEM "Half size",       M_SET_SIZ_HALF
+            MENUITEM "Normal size",     M_SET_SIZ_FULL
+#ifdef SUPPORT_DOUBLE
+            MENUITEM "Double size",     M_SET_SIZ_DOUBLE
 #endif
-		}
+            MENUITEM SEPARATOR
+            MENUITEM "Full screen",     M_SET_FULLSCREEN
+        }
 
-		MENUITEM "Use PCG-8100",		M_SET_PCG
+        MENUITEM "Use PCG-8100",        M_SET_PCG
 
-		MENUITEM SEPARATOR
+        MENUITEM SEPARATOR
 
-		POPUP "Mouse" {
-			MENUITEM "Nothing",		M_SET_MO_NO
-			MENUITEM "Mouse",		M_SET_MO_MOUSE
-			MENUITEM "Mouse as joy",	M_SET_MO_JOYMO
-		/*	MENUITEM "Joystick",		M_SET_MO_JOY	*/
-		}
+        POPUP "Mouse" {
+            MENUITEM "Nothing",         M_SET_MO_NO
+            MENUITEM "Mouse",           M_SET_MO_MOUSE
+            MENUITEM "Mouse as joy",    M_SET_MO_JOYMO
+        /*	MENUITEM "Joystick",        M_SET_MO_JOY	*/
+        }
 
-		POPUP "Cursor Key" {
-			MENUITEM "Default",		M_SET_CUR_DEF
-			MENUITEM "as Ten-key",		M_SET_CUR_TEN
-		}
+        POPUP "Cursor Key" {
+            MENUITEM "Default",         M_SET_CUR_DEF
+            MENUITEM "as Ten-key",      M_SET_CUR_TEN
+        }
 
-		MENUITEM "Software Numlock",		M_SET_NUMLOCK
-		MENUITEM "Kana (Romaji)",		M_SET_ROMAJI
+        MENUITEM "Software Numlock",    M_SET_NUMLOCK
+        MENUITEM "Kana (Romaji)",       M_SET_ROMAJI
 
-		MENUITEM SEPARATOR
-#ifdef	USE_SOUND
-#ifdef	USE_FMGEN
-		POPUP "FM Generator" {
-			MENUITEM "MAME embedded",	M_SET_FM_MAME
-			MENUITEM "fmgen",		M_SET_FM_FMGEN
-		}
+        MENUITEM SEPARATOR
+#ifdef USE_SOUND
+#ifdef USE_FMGEN
+        POPUP "FM Generator" {
+            MENUITEM "MAME embedded",   M_SET_FM_MAME
+            MENUITEM "fmgen",           M_SET_FM_FMGEN
+        }
 #endif
-		POPUP "Sample Frequency" {
-			MENUITEM "48000Hz",		M_SET_FRQ_48
-			MENUITEM "44100Hz",		M_SET_FRQ_44
-			MENUITEM "22050Hz",		M_SET_FRQ_22
-			MENUITEM "11025Hz",		M_SET_FRQ_11
-		}
+        POPUP "Sample Frequency" {
+            MENUITEM "48000Hz",         M_SET_FRQ_48
+            MENUITEM "44100Hz",         M_SET_FRQ_44
+            MENUITEM "22050Hz",         M_SET_FRQ_22
+            MENUITEM "11025Hz",         M_SET_FRQ_11
+        }
 
-		POPUP "Sound Buffer" {
-			MENUITEM "800ms",		M_SET_BUF_800
-			MENUITEM "400ms",		M_SET_BUF_400
-			MENUITEM "200ms",		M_SET_BUF_200
-			MENUITEM "100ms",		M_SET_BUF_100
-		}
+        POPUP "Sound Buffer" {
+            MENUITEM "800ms",           M_SET_BUF_800
+            MENUITEM "400ms",           M_SET_BUF_400
+            MENUITEM "200ms",           M_SET_BUF_200
+            MENUITEM "100ms",           M_SET_BUF_100
+        }
 #endif
-	}
+    }
 
-	POPUP "Disk" {
-		POPUP "Drive 1:" {
-			MENUITEM "<No Disk>",		M_DRV_DRV1_NO
+    POPUP "Disk" {
+        POPUP "Drive 1:" {
+            MENUITEM "<No Disk>",       M_DRV_DRV1_NO
 
-			MENUITEM SEPARATOR
+            MENUITEM SEPARATOR
 
-			MENUITEM "Change ...",		M_DRV_DRV1_CHG
-		}
+            MENUITEM "Change ...",      M_DRV_DRV1_CHG
+        }
 
-		POPUP "Drive 2:" {
-			MENUITEM "<No Disk>",		M_DRV_DRV2_NO
+        POPUP "Drive 2:" {
+            MENUITEM "<No Disk>",       M_DRV_DRV2_NO
 
-			MENUITEM SEPARATOR
+            MENUITEM SEPARATOR
 
-			MENUITEM "Change ...",		M_DRV_DRV2_CHG
-		}
+            MENUITEM "Change ...",      M_DRV_DRV2_CHG
+        }
 
-		MENUITEM SEPARATOR
+        MENUITEM SEPARATOR
 
-		MENUITEM "Set ...",			M_DRV_CHG
-		MENUITEM "Unset",			M_DRV_UNSET
-	}
+        MENUITEM "Set ...",             M_DRV_CHG
+        MENUITEM "Unset",               M_DRV_UNSET
+    }
 
-	POPUP "Misc" {
-		MENUITEM "Screen Capture",		M_MISC_CAPTURE
-		MENUITEM "Sound Record",		M_MISC_RECORD
-		
-		POPUP "Tape-Image [Load]" {
-			MENUITEM "Set ...",		M_MISC_CLOAD_S
-			MENUITEM "Unset",		M_MISC_CLOAD_U
-		}
-		POPUP "Tape-Image [Save]" {
-			MENUITEM "Set ...",		M_MISC_CSAVE_S
-			MENUITEM "Unset",		M_MISC_CSAVE_U
-		}
-		
-		MENUITEM SEPARATOR
+    POPUP "Misc" {
+        MENUITEM "Screen Capture",      M_MISC_CAPTURE
+        MENUITEM "Sound Record",        M_MISC_RECORD
 
-		POPUP "State-Load" {
-			MENUITEM "1",			M_MISC_SLOAD_1
-			MENUITEM "2",			M_MISC_SLOAD_2
-			MENUITEM "3",			M_MISC_SLOAD_3
-			MENUITEM "4",			M_MISC_SLOAD_4
-			MENUITEM "5",			M_MISC_SLOAD_5
-			MENUITEM "6",			M_MISC_SLOAD_6
-			MENUITEM "7",			M_MISC_SLOAD_7
-			MENUITEM "8",			M_MISC_SLOAD_8
-			MENUITEM "9",			M_MISC_SLOAD_9
-		}
-		POPUP "State-Save" {
-			MENUITEM "1",			M_MISC_SSAVE_1
-			MENUITEM "2",			M_MISC_SSAVE_2
-			MENUITEM "3",			M_MISC_SSAVE_3
-			MENUITEM "4",			M_MISC_SSAVE_4
-			MENUITEM "5",			M_MISC_SSAVE_5
-			MENUITEM "6",			M_MISC_SSAVE_6
-			MENUITEM "7",			M_MISC_SSAVE_7
-			MENUITEM "8",			M_MISC_SSAVE_8
-			MENUITEM "9",			M_MISC_SSAVE_9
-		}
+        POPUP "Tape-Image [Load]" {
+            MENUITEM "Set ...",         M_MISC_CLOAD_S
+            MENUITEM "Unset",           M_MISC_CLOAD_U
+        }
+        POPUP "Tape-Image [Save]" {
+            MENUITEM "Set ...",         M_MISC_CSAVE_S
+            MENUITEM "Unset",           M_MISC_CSAVE_U
+        }
 
-		MENUITEM SEPARATOR
+        MENUITEM SEPARATOR
 
-		MENUITEM "Show Status",			M_MISC_STATUS
-	}	
+        POPUP "State-Load" {
+            MENUITEM "1",               M_MISC_SLOAD_1
+            MENUITEM "2",               M_MISC_SLOAD_2
+            MENUITEM "3",               M_MISC_SLOAD_3
+            MENUITEM "4",               M_MISC_SLOAD_4
+            MENUITEM "5",               M_MISC_SLOAD_5
+            MENUITEM "6",               M_MISC_SLOAD_6
+            MENUITEM "7",               M_MISC_SLOAD_7
+            MENUITEM "8",               M_MISC_SLOAD_8
+            MENUITEM "9",               M_MISC_SLOAD_9
+        }
+        POPUP "State-Save" {
+            MENUITEM "1",               M_MISC_SSAVE_1
+            MENUITEM "2",               M_MISC_SSAVE_2
+            MENUITEM "3",               M_MISC_SSAVE_3
+            MENUITEM "4",               M_MISC_SSAVE_4
+            MENUITEM "5",               M_MISC_SSAVE_5
+            MENUITEM "6",               M_MISC_SSAVE_6
+            MENUITEM "7",               M_MISC_SSAVE_7
+            MENUITEM "8",               M_MISC_SSAVE_8
+            MENUITEM "9",               M_MISC_SSAVE_9
+        }
 
-	POPUP "Help" {
-		MENUITEM "About",			M_HELP_ABOUT
-	}
+        MENUITEM SEPARATOR
+
+        MENUITEM "Show Status",         M_MISC_STATUS
+    }
+
+    POPUP "Help" {
+        MENUITEM "About",               M_HELP_ABOUT
+    }
 }

--- a/RAQUASI88/src/WIN32/resource.h
+++ b/RAQUASI88/src/WIN32/resource.h
@@ -60,6 +60,8 @@
 #define M_SET_SIZ_HALF      20602
 #define M_SET_SIZ_DOUBLE    20603
 
+#define M_SET_FULLSCREEN    20650
+
 #define M_SET_PCG       20700
 
 #define M_SET_MO        20800

--- a/RAQUASI88/src/WIN32/retroachievements.cpp
+++ b/RAQUASI88/src/WIN32/retroachievements.cpp
@@ -21,6 +21,7 @@ FileInfo loaded_tape = FINFO_DEFAULT;
 FileInfo loading_file = FINFO_DEFAULT;
 FileInfo *loaded_title = 0;
 bool should_activate = true;
+static bool enable_loading = true;
 
 void reset_file_info(FileInfo *file)
 {
@@ -285,20 +286,21 @@ int RA_PrepareLoadNewRom(const char *file_name, int file_type)
     loading_file.title_id = RA_IdentifyRom(file_data, file_size);
     loading_file.file_type = file_type;
 
-    if (loaded_title != NULL && loaded_title->data_len > 0)
+    if (enable_loading && loaded_title != NULL && loaded_title->data_len > 0)
     {
         if (loaded_title->title_id != loading_file.title_id || loaded_title->file_type != loading_file.file_type)
         {
             if (!RA_WarnDisableHardcore("load a new title without ejecting all images and resetting the emulator"))
             {
-                free_file_info(&loading_file);
+                RA_AbortLoadNewRom();
                 return FALSE; /* 読み込みを中止する */
             }
         }
     }
 
 #if !RA_RELOAD_MULTI_DISK
-    should_activate = loaded_title != NULL &&
+    should_activate = should_activate ? true :
+        loaded_title != NULL &&
         loaded_title->title_id > 0 &&
         loaded_title->title_id == loading_file.title_id ?
         false :
@@ -328,15 +330,20 @@ void RA_CommitLoadNewRom()
 
     RA_UpdateAppTitle(loading_file.name);
 
-    if (should_activate)
+    if (enable_loading && should_activate)
     {
         /* 実績システムのイメージデータを初期化する */
         RA_ActivateGame(loading_file.title_id);
-        should_activate = true;
+        should_activate = false;
     }
 
     /* ロード中のデータをクリアする */
     reset_file_info(&loading_file);
+}
+
+void RA_AbortLoadNewRom()
+{
+    free_file_info(&loading_file);
 }
 
 void RA_OnGameClose(int file_type)
@@ -370,9 +377,20 @@ void RA_OnGameClose(int file_type)
 
     if (loaded_title == NULL && loading_file.data_len == 0)
     {
-        RA_UpdateAppTitle("");
-        RA_OnLoadNewRom(NULL, 0);
+        RA_ClearTitle();
     }
+}
+
+void RA_ClearTitle()
+{
+    RA_UpdateAppTitle("");
+    RA_OnLoadNewRom(NULL, 0);
+    should_activate = true;
+}
+
+void RA_ToggleLoad(int enabled)
+{
+    enable_loading = enabled;
 }
 
 int RA_HandleMenuEvent(int id)
@@ -423,7 +441,7 @@ void RA_RenderOverlayFrame(HDC hdc)
     input.m_bUpPressed = IS_KEY88_PRESS(KEY88_UP);
     input.m_bDownPressed = IS_KEY88_PRESS(KEY88_DOWN);
 
-    RA_UpdateRenderOverlay(hdc, &input, delta_time, &window_size, use_fullscreen, (bool)quasi88_is_pause());
+    RA_UpdateRenderOverlay(hdc, &input, delta_time, &window_size, (bool)quasi88_cfg_now_fullscreen(), (bool)quasi88_is_pause());
 
     last_tick = timeGetTime();
 }

--- a/RAQUASI88/src/WIN32/retroachievements.h
+++ b/RAQUASI88/src/WIN32/retroachievements.h
@@ -65,7 +65,10 @@ void RA_InitUI();
 void RA_InitMemory();
 int RA_PrepareLoadNewRom(const char *file_name, int file_type);
 void RA_CommitLoadNewRom();
+void RA_AbortLoadNewRom();
 void RA_OnGameClose(int file_type);
+void RA_ClearTitle();
+void RA_ToggleLoad(int enabled);
 int RA_HandleMenuEvent(int id);
 void RA_RenderOverlayFrame(HDC hdc);
 

--- a/RAQUASI88/src/graph.h
+++ b/RAQUASI88/src/graph.h
@@ -63,6 +63,13 @@ typedef struct {
     int     width;      /* 確保した画面の、描画可能エリア幅 */
     int     height;     /* 確保した画面の、描画可能エリア高さ  */
 
+    int     scaled_width; /* Win32用 スケール後の幅 */
+    int     scaled_height; /* Win32用 スケール後の高さ */
+    int     scaled_offx; /* Win32用 スケール後のオフセット */
+    int     scaled_offy;
+    int     window_offx; /* ウィンドウモード時のフレームのオフセット */
+    int     window_offy;
+
     int     byte_per_pixel; /* 確保した画面のピクセルあたりバイト数   */
                 /*  1, 2, 4 のいずれか     */
 

--- a/RAQUASI88/src/menu.c
+++ b/RAQUASI88/src/menu.c
@@ -1553,6 +1553,10 @@ static  void    cb_graph_resize(UNUSED_WIDGET, void *p)
     int new_size = (int)p;
 
     quasi88_cfg_set_size(new_size);
+
+    /*if (new_size > SCREEN_SIZE_FULL && quasi88_cfg_now_fullscreen()) {
+        quasi88_cfg_set_fullscreen(FALSE);
+    }*/
 }
 static  int get_graph_fullscreen(void)
 {
@@ -1564,6 +1568,10 @@ static  void    cb_graph_fullscreen(Q8tkWidget *widget, UNUSED_PARM)
 
     if (quasi88_cfg_can_fullscreen()) {
     quasi88_cfg_set_fullscreen(on);
+
+    /*if (on && quasi88_cfg_now_size() > SCREEN_SIZE_FULL) {
+        quasi88_cfg_set_size(SCREEN_SIZE_FULL);
+    }*/
     
     /* Q8TK カーソル有無設定 (全画面切替時に呼ぶ必要あり) */
     q8tk_set_cursor(now_swcursor);

--- a/RAQUASI88/src/q8tk-glib.c
+++ b/RAQUASI88/src/q8tk-glib.c
@@ -12,6 +12,7 @@
 
 #include "quasi88.h"
 #include "memory.h"     /* has_kanji_rom    */
+#include "screen.h"     /* screen_scale_* */
 
 #include "q8tk.h"
 #include "q8tk-glib.h"
@@ -172,6 +173,13 @@ void    q8gr_set_focus_screen(int x, int y, int sx, int sy, void *p)
 }
 void    *q8gr_get_focus_screen(int x, int y)
 {
+    int off_x = (screen_scale_dx + SCREEN_DX) * Q8GR_SCREEN_X / SCREEN_W;
+    int off_y = (screen_scale_dy + SCREEN_DY) * Q8GR_SCREEN_Y / SCREEN_H;
+    x -= off_x;
+    y -= off_y;
+    if (screen_scale_x) { x /= screen_scale_x; }
+    if (screen_scale_y) { y /= screen_scale_y; }
+
     if (0 <= x && x < Q8GR_SCREEN_X &&
     0 <= y && y < Q8GR_SCREEN_Y) {
     return focus_screen[y][x];

--- a/RAQUASI88/src/screen.h
+++ b/RAQUASI88/src/screen.h
@@ -145,6 +145,11 @@ extern  int SCREEN_DY;      /* 画面エリア左上とのオフセット   */
 extern  char    *screen_buf;        /* 描画バッファ先頭     */
 extern  char    *screen_start;      /* 画面先頭         */
 
+extern  double  screen_scale_x;     /* 画面のスケール因子 */
+extern  double  screen_scale_y;
+extern  int     screen_scale_dx;    /* 画面のスケール後のオフセット */
+extern  int     screen_scale_dy;
+
 extern  char    *status_buf;        /* ステータス全域 先頭     */
 extern  char    *status_start[3];   /* ステータス描画 先頭     */
 extern  int status_sx[3];       /* ステータス描画サイズ       */


### PR DESCRIPTION
Main changes are full screen and CLI support, and some fixes related to media swapping. Taken from the changelog (subtracting changes already merged in RAQUASI88 ver 1.1.1):

```
2019/02/14 ver 0.6.8
    New (新機能):
        Support launch options in the Win32 version (Win32版に起動オプションを有効にする)
    Other changes (他更新内容):
        Clear key press state when losing focus (フォーカスが外される時はキーの押下状態を解除)
        Various fixes to RAQUASI88 and the Win32 full screen mode (RAQUASI88、Win32版のフルスクリーンモードを色々修正)


2019/02/10 ver 0.6.7
    New (新機能):
        Implement integer scale -fullscreen on Win32 (Win32版に -fullscreen を実装)
```

The squash commit contains the list of merged commits (it is not possible to pull from a subtree without squashing once the history has already been squashed). Notably the protection against cross-title hot-swapping is improved, and a few uncommon situations where the current loaded title was not set or cleared correctly were fixed.

I had an intermediary release with preliminary full screen support a few days ago, so please release as 1.1.3 and not 1.1.2.

The only files to change on deployment are the binary and the documents (HISTORY.txt)