### PR TITLE
RAProject64: avoid duplicating ROM in memory for hash calculation

### DIFF
--- a/RAProject64/Source/Project64-core/N64System/N64Class.cpp
+++ b/RAProject64/Source/Project64-core/N64System/N64Class.cpp
@@ -361,7 +361,7 @@ void CN64System::RunLoadedImage(void)
 	// #RA
 	RA_ClearMemoryBanks();
 	RA_InstallMemoryBank( 0, RAMByteReader, RAMByteWriter, g_MMU->RdramSize() );
-	RA_OnLoadNewRom( RomImage, FileSize );
+    RA_ActivateGame( g_RAGameId );
     WriteTrace(TraceN64System, TraceDebug, "Done");
 }
 

--- a/RAProject64/Source/Project64-core/N64System/N64RomClass.cpp
+++ b/RAProject64/Source/Project64-core/N64System/N64RomClass.cpp
@@ -24,9 +24,8 @@
 
 // #RA
 #include "RA_Implementation\RA_Implementation.h"
-
-uint32_t FileSize;
-uint8_t* RomImage(NULL);
+#include "..\..\RA_Integration\src\RA_Interface.h"
+unsigned int g_RAGameId = 0;
 
 CN64Rom::CN64Rom() :
 m_ROMImage(NULL),
@@ -60,7 +59,6 @@ bool CN64Rom::AllocateRomImage(uint32_t RomFileSize)
     m_ROMImage = Image;
     m_RomFileSize = RomFileSize;
 
-	RomImage = new uint8_t[RomFileSize + 0x1000];
     return true;
 }
 
@@ -135,8 +133,8 @@ bool CN64Rom::AllocateAndLoadN64Image(const char * FileLoc, bool LoadBootCodeOnl
         return false;
     }
 
-	FileSize = m_RomFileSize;
-	memcpy( RomImage, m_ROMImage, FileSize );
+    // calculate the hash before byteswapping the ROM.
+    g_RAGameId = RA_IdentifyRom(m_ROMImage, m_RomFileSize);
 
     g_Notify->DisplayMessage(5, MSG_BYTESWAP);
     ByteSwapRom();
@@ -226,8 +224,7 @@ bool CN64Rom::AllocateAndLoadZipImage(const char * FileLoc, bool LoadBootCodeOnl
             }
             FoundRom = true;
 
-			FileSize = m_RomFileSize;
-			memcpy( RomImage, m_ROMImage, FileSize );
+            g_RAGameId = RA_IdentifyRom(m_ROMImage, m_RomFileSize);
 
             g_Notify->DisplayMessage(5, MSG_BYTESWAP);
             ByteSwapRom();

--- a/RAProject64/Source/RA_Implementation/RA_Implementation.h
+++ b/RAProject64/Source/RA_Implementation/RA_Implementation.h
@@ -32,6 +32,5 @@ extern void RA_InitShared();
 //extras
 extern HWND hMainWindow;
 extern HWND hMainWindowStatusBar;
-extern uint32_t FileSize;
-extern uint8_t* RomImage;
+extern unsigned int g_RAGameId;
 extern bool doRAThread;


### PR DESCRIPTION
Additionally, the duplicated ROM was not being freed, causing a memory leak. General memory usage by the emulator is decreased by the size of the ROM.

Leverages the new `RA_IdentifyRom` and `RA_ActivateGame` methods introduced in DLL 0.75.