### PR TITLE
Complete checklist for RAProject64

### DIFF
--- a/RAProject64/Source/Project64-core/N64System/N64RomClass.cpp
+++ b/RAProject64/Source/Project64-core/N64System/N64RomClass.cpp
@@ -133,6 +133,14 @@ bool CN64Rom::AllocateAndLoadN64Image(const char * FileLoc, bool LoadBootCodeOnl
         return false;
     }
 
+    const char* ptr = strrchr(FileLoc, '\\');
+    if (ptr == NULL)
+        ptr = FileLoc;
+    else
+        ++ptr;
+    strncpy(g_RAGameFileName, ptr, sizeof(g_RAGameFileName));
+    g_RAGameFileName[sizeof(g_RAGameFileName) - 1] = '\0';
+
     // calculate the hash before byteswapping the ROM.
     g_RAGameId = RA_IdentifyRom(m_ROMImage, m_RomFileSize);
 
@@ -224,6 +232,8 @@ bool CN64Rom::AllocateAndLoadZipImage(const char * FileLoc, bool LoadBootCodeOnl
             }
             FoundRom = true;
 
+            strncpy(g_RAGameFileName, zname, sizeof(g_RAGameFileName));
+            g_RAGameFileName[sizeof(g_RAGameFileName) - 1] = '\0';
             g_RAGameId = RA_IdentifyRom(m_ROMImage, m_RomFileSize);
 
             g_Notify->DisplayMessage(5, MSG_BYTESWAP);

--- a/RAProject64/Source/Project64-core/N64System/SpeedLimiterClass.cpp
+++ b/RAProject64/Source/Project64-core/N64System/SpeedLimiterClass.cpp
@@ -14,6 +14,8 @@
 
 #include <Common/Util.h>
 
+#include "../../RA_Integration/src/RA_Interface.h"
+
 // ---------------------------------------------------
 
 const uint32_t CSpeedLimiter::m_DefaultSpeed = 60;
@@ -99,6 +101,9 @@ void CSpeedLimiter::AlterSpeed( const ESpeedChange SpeedChange )
 		m_Speed += 1 * SpeedFactor;
 	}
 
+    if (m_Speed < m_DefaultSpeed && RA_HardcoreModeIsActive())
+        m_Speed = m_DefaultSpeed;
+
 	SpeedChanged(m_Speed);
 	FixSpeedRatio();
 }
@@ -109,7 +114,12 @@ void CSpeedLimiter::SetSpeed(int Speed)
     {
         Speed = 1;
     }
-    m_Speed = Speed;
+
+    if (Speed < m_DefaultSpeed && RA_HardcoreModeIsActive())
+        m_Speed = m_DefaultSpeed;
+    else
+        m_Speed = Speed;
+
     SpeedChanged(m_Speed);
     FixSpeedRatio();
 }

--- a/RAProject64/Source/Project64/UserInterface/GuiClass.cpp
+++ b/RAProject64/Source/Project64/UserInterface/GuiClass.cpp
@@ -1167,6 +1167,11 @@ LRESULT CALLBACK CMainGui::MainGui_Proc(HWND hWnd, DWORD uMsg, DWORD wParam, DWO
             }
         }
         break;
+    case WM_CLOSE:
+        if (!RA_ConfirmLoadNewRom(true))
+            return 0;
+        DestroyWindow(hWnd);
+        break;
     case WM_DESTROY:
         WriteTrace(TraceUserInterface, TraceDebug, "WM_DESTROY - start");
         {

--- a/RAProject64/Source/Project64/UserInterface/MainMenuClass.cpp
+++ b/RAProject64/Source/Project64/UserInterface/MainMenuClass.cpp
@@ -358,15 +358,9 @@ bool CMainMenu::ProcessMessage(HWND hWnd, DWORD /*FromAccelerator*/, DWORD MenuI
         }
         break;
     case ID_OPTIONS_INCREASE_SPEED:
-        if (RA_HardcoreModeIsActive())
-            break;
-
         g_BaseSystem->AlterSpeed(CSpeedLimiter::INCREASE_SPEED);
         break;
     case ID_OPTIONS_DECREASE_SPEED:
-        if (RA_HardcoreModeIsActive())
-            break;
-
         g_BaseSystem->AlterSpeed(CSpeedLimiter::DECREASE_SPEED);
         break;
     case ID_OPTIONS_FULLSCREEN:

--- a/RAProject64/Source/Project64/UserInterface/MainMenuClass.cpp
+++ b/RAProject64/Source/Project64/UserInterface/MainMenuClass.cpp
@@ -156,6 +156,9 @@ void CMainMenu::OnRomInfo(HWND hWnd)
 
 void CMainMenu::OnEndEmulation(void)
 {
+    if (!RA_ConfirmLoadNewRom(false))
+        return;
+
     CGuard Guard(m_CS);
     WriteTrace(TraceUserInterface, TraceDebug, "ID_FILE_ENDEMULATION");
     if (g_BaseSystem)
@@ -277,7 +280,10 @@ bool CMainMenu::ProcessMessage(HWND hWnd, DWORD /*FromAccelerator*/, DWORD MenuI
         WriteTrace(TraceUserInterface, TraceDebug, "ID_FILE_ROMDIRECTORY 3");
         break;
     case ID_FILE_REFRESHROMLIST: m_Gui->RefreshRomList(); break;
-    case ID_FILE_EXIT:           DestroyWindow((HWND)hWnd); break;
+    case ID_FILE_EXIT:
+        if (RA_ConfirmLoadNewRom(true))
+            DestroyWindow((HWND)hWnd);
+        break;
     case ID_SYSTEM_RESET_SOFT:
         WriteTrace(TraceUserInterface, TraceDebug, "ID_SYSTEM_RESET_SOFT");
         g_BaseSystem->ExternalEvent(SysEvent_ResetCPU_Soft);

--- a/RAProject64/Source/Project64/UserInterface/MainMenuClass.cpp
+++ b/RAProject64/Source/Project64/UserInterface/MainMenuClass.cpp
@@ -520,10 +520,22 @@ bool CMainMenu::ProcessMessage(HWND hWnd, DWORD /*FromAccelerator*/, DWORD MenuI
     case ID_DEBUGGER_GENERATELOG:
         g_Settings->SaveBool(Logging_GenerateLog, !g_Settings->LoadBool(Logging_GenerateLog));
         break;
-    case ID_DEBUGGER_DUMPMEMORY: m_Gui->Debug_ShowMemoryDump(); break;
-    case ID_DEBUGGER_SEARCHMEMORY: m_Gui->Debug_ShowMemorySearch(); break;
-    case ID_DEBUGGER_MEMORY: m_Gui->Debug_ShowMemoryWindow(); break;
-    case ID_DEBUGGER_TLBENTRIES: m_Gui->Debug_ShowTLBWindow(); break;
+    case ID_DEBUGGER_DUMPMEMORY:
+        if (RA_WarnDisableHardcore("dump memory"))
+            m_Gui->Debug_ShowMemoryDump();
+        break;
+    case ID_DEBUGGER_SEARCHMEMORY:
+        if (RA_WarnDisableHardcore("search memory"))
+            m_Gui->Debug_ShowMemorySearch();
+        break;
+    case ID_DEBUGGER_MEMORY:
+        if (RA_WarnDisableHardcore("view memory"))
+            m_Gui->Debug_ShowMemoryWindow();
+        break;
+    case ID_DEBUGGER_TLBENTRIES:
+        if (RA_WarnDisableHardcore("view TLB entries"))
+            m_Gui->Debug_ShowTLBWindow();
+        break;
     case ID_DEBUGGER_INTERRUPT_SP: g_BaseSystem->ExternalEvent(SysEvent_Interrupt_SP); break;
     case ID_DEBUGGER_INTERRUPT_SI: g_BaseSystem->ExternalEvent(SysEvent_Interrupt_SI); break;
     case ID_DEBUGGER_INTERRUPT_AI: g_BaseSystem->ExternalEvent(SysEvent_Interrupt_AI); break;
@@ -913,9 +925,9 @@ void CMainMenu::FillOutMenu(HMENU hMenu)
     }
     SystemMenu.push_back(MENU_ITEM(SPLITER));
     SystemMenu.push_back(MENU_ITEM(SUB_MENU, MENU_CURRENT_SAVE, EMPTY_STDSTR, &CurrentSaveMenu));
-    SystemMenu.push_back(MENU_ITEM(SPLITER));
-    SystemMenu.push_back(MENU_ITEM(ID_SYSTEM_CHEAT, MENU_CHEAT, m_ShortCuts.ShortCutString(ID_SYSTEM_CHEAT, AccessLevel)));
-    SystemMenu.push_back(MENU_ITEM(ID_SYSTEM_GSBUTTON, MENU_GS_BUTTON, m_ShortCuts.ShortCutString(ID_SYSTEM_GSBUTTON, AccessLevel)));
+    //SystemMenu.push_back(MENU_ITEM(SPLITER));
+    //SystemMenu.push_back(MENU_ITEM(ID_SYSTEM_CHEAT, MENU_CHEAT, m_ShortCuts.ShortCutString(ID_SYSTEM_CHEAT, AccessLevel)));
+    //SystemMenu.push_back(MENU_ITEM(ID_SYSTEM_GSBUTTON, MENU_GS_BUTTON, m_ShortCuts.ShortCutString(ID_SYSTEM_GSBUTTON, AccessLevel)));
 
     /* Option Menu
     ****************/

--- a/RAProject64/Source/RA_Implementation/RA_Implementation.cpp
+++ b/RAProject64/Source/RA_Implementation/RA_Implementation.cpp
@@ -6,6 +6,8 @@
 
 //#include "Project64\UserInterface\Settings\SettingsPage.h"
 
+char g_RAGameFileName[64] = "";
+
 // returns -1 if not found
 int GetMenuItemIndex(HMENU hMenu, const char* ItemName)
 {
@@ -67,8 +69,7 @@ void RebuildMenu()
 //	 for the ROM, if one can be inferred from the ROM.
 void GetEstimatedGameTitle( char* sNameOut )
 {
-	//if( emu && emu->get_NES_ROM() )
-	//	strcpy_s( sNameOut, 49, emu->get_NES_ROM()->GetRomName() );
+    strcpy(sNameOut, g_RAGameFileName);
 }
 
 void ResetEmulation()

--- a/RAProject64/Source/RA_Implementation/RA_Implementation.cpp
+++ b/RAProject64/Source/RA_Implementation/RA_Implementation.cpp
@@ -76,6 +76,10 @@ void ResetEmulation()
 {
 	if (g_Settings->LoadBool(GameRunning_CPU_Running) || g_Settings->LoadBool(GameRunning_CPU_Paused))
 		g_BaseSystem->ExternalEvent(SysEvent_ResetCPU_Hard);
+
+    // ensure speed is not lower than default
+    if (RA_HardcoreModeIsActive())
+        g_BaseSystem->SetSpeed(g_BaseSystem->GetSpeed());
 }
 
 void LoadROM( const char* sFullPath )

--- a/RAProject64/Source/RA_Implementation/RA_Implementation.h
+++ b/RAProject64/Source/RA_Implementation/RA_Implementation.h
@@ -34,3 +34,4 @@ extern HWND hMainWindow;
 extern HWND hMainWindowStatusBar;
 extern unsigned int g_RAGameId;
 extern bool doRAThread;
+extern char g_RAGameFileName[64];


### PR DESCRIPTION
Changes made:
* pass filename back to Unknown Game dialog
* allow speed above 100% in hardcore mode; reset to 100% when switching to hardcore mode
* warn about changes when closing emulator or game
* disable debugger windows in hardcore mode
* remove GameShark button and Cheat menu items entirely

[RAP64-0.59-checklist.txt](https://github.com/RetroAchievements/RAEmus/files/2897976/RAP64-0.59.txt)
