### PR TITLE
Complete checklist for RAMeka

### DIFF
--- a/NewEmuChecklist.txt
+++ b/NewEmuChecklist.txt
@@ -47,8 +47,8 @@ RetroAchievements Emulator Requirements:
   [ ] Fast-forward is allowed
   [ ] Rewind is allowed
   [ ] Frame advance is allowed
+    [ ] Overlay should not be displayed when using frame advance (don't call RA_SetPaused)
   [ ] Recording playback is allowed
-  [ ] Overlay should not be displayed when using frame advance (don't call RA_SetPaused)
   [ ] Switching to Hardcore resets the emulator (RA_InstallSharedFunctions>RA_ResetEmulation)
   [ ] Switching to Hardcore resets the emulator speed to 100%
   [ ] Switching to Hardcore closes any emulator specific tools for viewing/modifying memory

--- a/RAMeka/meka/srcs/RA_Implementation.cpp
+++ b/RAMeka/meka/srcs/RA_Implementation.cpp
@@ -129,8 +129,9 @@ void RebuildMenu()
 //	 for the ROM, if one can be inferred from the ROM.
 void GetEstimatedGameTitle(char* sNameOut)
 {
-	//if( emu && emu->get_NES_ROM() )
-	//	strcpy_s( sNameOut, 49, emu->get_NES_ROM()->GetRomName() );
+    strncpy(sNameOut, g_env.Paths.MediaImageFile, 64);
+    sNameOut[63] = '\0';
+    StrPath_RemoveExtension(sNameOut);
 }
 
 

--- a/RAMeka/meka/srcs/app_cheatfinder.c
+++ b/RAMeka/meka/srcs/app_cheatfinder.c
@@ -10,6 +10,10 @@
 #include "desktop.h"
 #include "g_widget.h"
 
+//##RA
+#include "RA_Interface.h"
+#include "RA_Implementation.h"
+
 //-----------------------------------------------------------------------------
 // Definitions
 //-----------------------------------------------------------------------------
@@ -265,11 +269,10 @@ void	CheatFinder_Update(t_cheat_finder* app)
 	if (!app->active)
 		return;
 
-	//Not sure if cheatfinder really needs to be deactivated if hardcore is active.
-	//if (RAMeka_HardcoreIsActiveCheck(SCF_CHEAT_FINDER)) {
-	//	CheatFinder_SwitchMainInstance()
-	//	return;
-	//}
+	if (RA_HardcoreModeIsActive()) {
+        CheatFinder_SwitchMainInstance();
+		return;
+	}
 
 	al_set_target_bitmap(app->box->gfx_buffer);
 
@@ -617,12 +620,11 @@ void	CheatFinder_SwitchMainInstance()
 {
 	t_cheat_finder *app = g_CheatFinder_MainInstance;
 
-	//Not sure if hardcore deactivation is really required in case of cheat finder alone
-	//if (!app->active) {
-	//	if (!RA_WarnDisableHardcore("find cheats")) {
-	//		return; //user did not agree to a hardcore mode deactivation, abandon cheat finder activation
-	//	}
-	//}
+	if (!app->active) {
+		if (!RA_WarnDisableHardcore("find cheats")) {
+			return; //user did not agree to a hardcore mode deactivation, abandon cheat finder activation
+		}
+	}
 
 	app->active ^= 1;
 	gui_box_show(app->box, app->active, TRUE);

--- a/RAMeka/meka/srcs/app_filebrowser.c
+++ b/RAMeka/meka/srcs/app_filebrowser.c
@@ -13,6 +13,10 @@
 #include "inputs_t.h"
 #include "vlfn.h"
 
+//#RA
+#include "RA_Interface.h"
+#include "RA_Implementation.h"
+
 //-----------------------------------------------------------------------------
 // Data
 //-----------------------------------------------------------------------------
@@ -902,7 +906,8 @@ void	FB_OpenSelectedEntry()
         }
     case FB_ENTRY_TYPE_FILE:
         {
-			FB_OpenFile(entry->file_name);
+            if (RA_ConfirmLoadNewRom(false))
+    			FB_OpenFile(entry->file_name);
             break;
         }
     default:

--- a/RAMeka/meka/srcs/file.c
+++ b/RAMeka/meka/srcs/file.c
@@ -215,6 +215,10 @@ bool    Reload_ROM()
         Msg(MSGT_USER, "%s", Msg_Get(MSG_LoadROM_Reload_No_ROM));
         return false;
     }
+
+    if (!RA_ConfirmLoadNewRom(false))
+        return false;
+
     if (Load_ROM(LOAD_MODE_GUI, FALSE))
     {
         Msg(MSGT_USER, "%s", Msg_Get(MSG_LoadROM_Reload_Reloaded));

--- a/RAMeka/meka/srcs/inputs.c
+++ b/RAMeka/meka/srcs/inputs.c
@@ -26,6 +26,10 @@
 #include "video.h"
 #include "sound/sound_logging.h"
 
+//##RA
+#include "RA_Interface.h"
+#include "RA_Implementation.h"
+
 //-----------------------------------------------------------------------------
 // Data
 //-----------------------------------------------------------------------------
@@ -136,8 +140,13 @@ void        Inputs_Check_GUI (bool sk1100_pressed)
                 Action_Switch_Layer_Sprites();
 
             // Hard Pause
-            if (Inputs_KeyPressed (ALLEGRO_KEY_F12, FALSE))
+            if (Inputs_KeyPressed(ALLEGRO_KEY_F12, FALSE))
+            {
                 g_machine_pause_requests = 1;
+
+                //RA
+                RAMeka_RA_SetPaused((g_machine_flags & MACHINE_PAUSED) == 0);
+            }
         }
         break;
     case ALLEGRO_KEYMOD_CTRL:
@@ -152,7 +161,10 @@ void        Inputs_Check_GUI (bool sk1100_pressed)
 
 			// Next frame (pause hack)
 			if (Inputs_KeyPressed (ALLEGRO_KEY_F12, FALSE))
-				g_machine_pause_requests = (g_machine_flags & MACHINE_PAUSED) ? 2 : 1;
+            {
+                if (!RA_HardcoreModeIsActive())
+    				g_machine_pause_requests = (g_machine_flags & MACHINE_PAUSED) ? 2 : 1;
+            }
 
 			// Load State & Continue
 			if (Inputs_KeyPressed(ALLEGRO_KEY_F7, FALSE))

--- a/RAMeka/meka/srcs/machine.c
+++ b/RAMeka/meka/srcs/machine.c
@@ -52,9 +52,6 @@ void    Machine_Pause()
     if (g_machine_pause_requests > 0)
         g_machine_pause_requests--;
 
-	//RA
-	RAMeka_RA_SetPaused((g_machine_flags & MACHINE_PAUSED) != 0);
-
     // Verbose
     if (g_machine_flags & MACHINE_PAUSED)
     {

--- a/RAMeka/meka/srcs/video.c
+++ b/RAMeka/meka/srcs/video.c
@@ -386,6 +386,8 @@ void	Video_UpdateEvents()
 		switch (key_event.type)
 		{
 		case ALLEGRO_EVENT_DISPLAY_CLOSE:
+            if (!RA_ConfirmLoadNewRom(true))
+                break;
 			if (g_env.state == MEKA_STATE_INIT || g_env.state == MEKA_STATE_SHUTDOWN)
 				break;
 			opt.Force_Quit = TRUE;

--- a/RAMeka/meka/srcs/vmachine.c
+++ b/RAMeka/meka/srcs/vmachine.c
@@ -116,6 +116,9 @@ void    Machine_Remove_Cartridge (void)
 
 void    Free_ROM (void)
 {
+    if (!RA_ConfirmLoadNewRom(false))
+        return;
+
     // Call BMemory_Save() only if Machine_Off() won't call it
     // FIXME: this is some crap hack, the whole machine thing need to be rewritten
     if (!(g_machine_flags & MACHINE_POWER_ON))


### PR DESCRIPTION
Changes made:

* pass filename back to Unknown Game dialog
* warn about changes when closing emulator or game
* disable debugger windows in hardcore mode
* don't show overlay when using frame advance

[RAMeka-0.22-checklist.txt](https://github.com/RetroAchievements/RAEmus/files/2908457/RAMeka-0.22.txt)
