### PR TITLE
Complete checklist for RAVBA

### DIFF
--- a/RAVBA-M/src/win32/MainWnd.cpp
+++ b/RAVBA-M/src/win32/MainWnd.cpp
@@ -429,6 +429,9 @@ BOOL MainWnd::OnRAMenu(UINT nID)
 
 void MainWnd::OnClose()
 {
+  if (!RA_ConfirmLoadNewRom(true))
+    return;
+
   emulating = false;
   CWnd::OnClose();
 }
@@ -465,6 +468,9 @@ void GBAByteWriterWorkRAM( size_t nOffs, unsigned char nVal )
 
 bool MainWnd::FileRun()
 {
+  if (!RA_ConfirmLoadNewRom(false))
+    return true;
+
   // save battery file before we change the filename...
   if(rom != NULL || gbRom != NULL) {
     if(theApp.autoSaveLoadCheatList)

--- a/RAVBA-M/src/win32/MainWndFile.cpp
+++ b/RAVBA-M/src/win32/MainWndFile.cpp
@@ -145,6 +145,9 @@ void MainWnd::OnFileExit()
 
 void MainWnd::OnFileClose()
 {
+  if (!RA_ConfirmLoadNewRom(false))
+    return;
+
   // save battery file before we change the filename...
   if(rom != NULL || gbRom != NULL) {
     if(theApp.autoSaveLoadCheatList)

--- a/RAVBA-M/src/win32/MainWndOptions.cpp
+++ b/RAVBA-M/src/win32/MainWndOptions.cpp
@@ -36,6 +36,8 @@
 
 #include <tchar.h>
 
+//##RA
+#include "RA_Interface.h"
 
 void MainWnd::OnOptionsFrameskipThrottleNothrottle()
 {
@@ -51,6 +53,9 @@ void MainWnd::OnUpdateOptionsFrameskipThrottleNothrottle(CCmdUI* pCmdUI)
 
 void MainWnd::OnOptionsFrameskipThrottle25()
 {
+  if (RA_HardcoreModeIsActive())
+    return;
+
 	theApp.updateThrottle( 25 );
   theApp.autoFrameSkip = false;
 }
@@ -63,6 +68,9 @@ void MainWnd::OnUpdateOptionsFrameskipThrottle25(CCmdUI* pCmdUI)
 
 void MainWnd::OnOptionsFrameskipThrottle50()
 {
+  if (RA_HardcoreModeIsActive())
+    return;
+
 	theApp.updateThrottle( 50 );
   theApp.autoFrameSkip = false;
 }
@@ -75,6 +83,9 @@ void MainWnd::OnUpdateOptionsFrameskipThrottle50(CCmdUI* pCmdUI)
 
 void MainWnd::OnOptionsFrameskipThrottle100()
 {
+  if (RA_HardcoreModeIsActive())
+    return;
+
 	theApp.updateThrottle( 100 );
   theApp.autoFrameSkip = false;
 }
@@ -87,6 +98,9 @@ void MainWnd::OnUpdateOptionsFrameskipThrottle100(CCmdUI* pCmdUI)
 
 void MainWnd::OnOptionsFrameskipThrottle150()
 {
+  if (RA_HardcoreModeIsActive())
+    return;
+
 	theApp.updateThrottle( 150 );
 theApp.autoFrameSkip = false;
 }
@@ -99,6 +113,9 @@ void MainWnd::OnUpdateOptionsFrameskipThrottle150(CCmdUI* pCmdUI)
 
 void MainWnd::OnOptionsFrameskipThrottle200()
 {
+  if (RA_HardcoreModeIsActive())
+    return;
+
 	theApp.updateThrottle( 200 );
   theApp.autoFrameSkip = false;
 }
@@ -111,6 +128,9 @@ void MainWnd::OnUpdateOptionsFrameskipThrottle200(CCmdUI* pCmdUI)
 
 void MainWnd::OnOptionsFrameskipThrottleOther()
 {
+    if (RA_HardcoreModeIsActive())
+        return;
+
 	Throttle dlg;
 	unsigned short v = (unsigned short)dlg.DoModal();
 
@@ -152,6 +172,9 @@ void MainWnd::OnUpdateOptionsFrameskipAutomatic(CCmdUI* pCmdUI)
 
 BOOL MainWnd::OnOptionsFrameskip(UINT nID)
 {
+  if (RA_HardcoreModeIsActive())
+    return TRUE;
+
   switch(nID) {
   case ID_OPTIONS_VIDEO_FRAMESKIP_0:
   case ID_OPTIONS_VIDEO_FRAMESKIP_1:

--- a/RAVBA-M/src/win32/MainWndTools.cpp
+++ b/RAVBA-M/src/win32/MainWndTools.cpp
@@ -625,6 +625,9 @@ void MainWnd::OnUpdateToolsPlayStopmovieplaying(CCmdUI* pCmdUI)
 
 void MainWnd::OnToolsRewind()
 {
+  if (!RA_WarnDisableHardcore("rewind"))
+    return;
+
   if(emulating && theApp.emulator.emuReadMemState && theApp.rewindMemory && theApp.rewindCount) {
     theApp.rewindPos = --theApp.rewindPos & 7;
     theApp.emulator.emuReadMemState(&theApp.rewindMemory[REWIND_SIZE*theApp.rewindPos], REWIND_SIZE);

--- a/RAVBA-M/src/win32/RA_Implementation.cpp
+++ b/RAVBA-M/src/win32/RA_Implementation.cpp
@@ -54,6 +54,12 @@ void ResetEmulation()
 {
 	if( theApp.emulator.emuReset != NULL )
 		theApp.emulator.emuReset();
+
+    theApp.updateThrottle(0);
+    theApp.autoFrameSkip = true;
+    theApp.throttle = false;
+    frameSkip = 0;
+    systemFrameSkip = 0;
 }
 
 void LoadROM( const char* sFullPath )

--- a/RAVBA-M/src/win32/RA_Implementation.cpp
+++ b/RAVBA-M/src/win32/RA_Implementation.cpp
@@ -6,6 +6,12 @@
 #include "../gb/gbGlobals.h"
 #include "../gba/Globals.h"
 
+#include "../win32/Disassemble.h"
+#include "../win32/GBDisassemble.h"
+#include "../win32/MemoryViewerDlg.h"
+#include "../win32/GBMemoryViewerDlg.h"
+#include "../win32/MapView.h"
+#include "../win32/GBMapView.h"
 
 //	Return whether a game has been loaded. Should return FALSE if
 //	 no ROM is loaded, or a ROM has been unloaded.
@@ -50,6 +56,25 @@ void GetEstimatedGameTitle( char* sNameOut )
 	}
 }
 
+static BOOL CALLBACK CloseDebugWindows(HWND hWnd, LPARAM lParam)
+{
+    CWnd *pWnd = CWnd::FromHandle(hWnd);
+    if (dynamic_cast<Disassemble*>(pWnd) != NULL)
+        reinterpret_cast<CDialog*>(pWnd)->EndDialog(IDCANCEL);
+    else if (dynamic_cast<GBDisassemble*>(pWnd) != NULL)
+        reinterpret_cast<CDialog*>(pWnd)->EndDialog(IDCANCEL);
+    else if (dynamic_cast<MemoryViewerDlg*>(pWnd) != NULL)
+        reinterpret_cast<CDialog*>(pWnd)->EndDialog(IDCANCEL);
+    else if (dynamic_cast<GBMemoryViewerDlg*>(pWnd) != NULL)
+        reinterpret_cast<CDialog*>(pWnd)->EndDialog(IDCANCEL);
+    else if (dynamic_cast<MapView*>(pWnd) != NULL)
+        reinterpret_cast<CDialog*>(pWnd)->EndDialog(IDCANCEL);
+    else if (dynamic_cast<GBMapView*>(pWnd) != NULL)
+        reinterpret_cast<CDialog*>(pWnd)->EndDialog(IDCANCEL);
+
+    return TRUE;
+}
+
 void ResetEmulation()
 {
 	if( theApp.emulator.emuReset != NULL )
@@ -60,6 +85,10 @@ void ResetEmulation()
     theApp.throttle = false;
     frameSkip = 0;
     systemFrameSkip = 0;
+
+    DWORD processid;
+    DWORD threadid = GetWindowThreadProcessId(theApp.m_pMainWnd->m_hWnd, &processid);
+    EnumThreadWindows(threadid, &CloseDebugWindows, 0);
 }
 
 void LoadROM( const char* sFullPath )

--- a/RAVBA-M/src/win32/VBA.cpp
+++ b/RAVBA-M/src/win32/VBA.cpp
@@ -1090,6 +1090,8 @@ void systemFrame()
 #ifdef LOG_PERFORMANCE
 	systemSpeedTable[systemSpeedCounter++ % PERFORMANCE_INTERVAL] = systemSpeed;
 #endif
+
+    RA_DoAchievementsFrame();
 }
 
 
@@ -1315,7 +1317,6 @@ BOOL VBA::OnIdle(LONG lCount)
 			SetCursor(NULL);
 		  }
 		}
-		RA_DoAchievementsFrame();
 	  }
 	  else if( active && paused )
 	  {

--- a/RAVBA-M/src/win32/VBA.cpp
+++ b/RAVBA-M/src/win32/VBA.cpp
@@ -529,8 +529,8 @@ BOOL VBA::InitInstance()
 
 	RA_Init( ( (MainWnd*)m_pMainWnd )->GetSafeHwnd(), RA_VisualboyAdvance, RAVBA_VERSION );
 	RA_InitShared();
-	RA_RebuildMenu();
-	RA_AttemptLogin( true );
+    theApp.updateMenuBar();
+    RA_AttemptLogin( true );
 
   return TRUE;
 }

--- a/RAVBA-M/src/win32/VBA.cpp
+++ b/RAVBA-M/src/win32/VBA.cpp
@@ -859,9 +859,6 @@ void VBA::updateFilter()
 
 void VBA::updateThrottle( unsigned short throttle )
 {
-    if (RA_HardcoreModeIsActive())
-        return;
-
 	this->throttle = throttle;
 
 	if( throttle ) {


### PR DESCRIPTION
* only call `RA_DoAchievementsFrame` once per frame - this could cause HitCounts to raise faster than expected
* warn about changes when closing emulator or game
* disable throttle and frameskip options in hardcore. they usually cause the emulator to run fast, but under certain combinations, you can actually slow down the emulator, which is not allowed in hardcore
* disable rewind in hardcore
* close debugger windows when switching to hardcore

[RAVBA-M-checklist.txt](https://github.com/RetroAchievements/RAEmus/files/2950143/RAVBA-M-0.57.txt)