### PR TITLE
give RA actual main Meka window, not Console window

### DIFF
--- a/RAMeka/meka/srcs/RA_Implementation.cpp
+++ b/RAMeka/meka/srcs/RA_Implementation.cpp
@@ -204,7 +204,9 @@ void RAMeka_MakePlaceholderRAMenu() {
 //Various calls to initialise RA, login, install menus, etc
 void RAMeka_InstallRA() {
 
-	RA_Init(ConsoleHWND(), RA_Meka, RAMEKA_VERSION);
+    HWND hWnd = al_get_win_window_handle(g_display);
+
+	RA_Init(hWnd, RA_Meka, RAMEKA_VERSION);
 
 	RA_InitShared();
 	RA_UpdateAppTitle("RAMEKA");

--- a/RAMeka/meka/srcs/meka.c
+++ b/RAMeka/meka/srcs/meka.c
@@ -338,6 +338,8 @@ static void Init_GUI(void)
 {
     ConsolePrintf ("%s\n", Msg_Get(MSG_Init_GUI));
     GUI_Init();
+
+    RAMeka_RA_Setup(); //Attach RA Menu to Console and Initialise RA System
 }
 
 // MAIN FUNCTION --------------------------------------------------------------
@@ -355,7 +357,6 @@ int main(int argc, char **argv)
 
     ConsoleInit(); // First thing to do
     #ifdef ARCH_WIN32
-		RAMeka_RA_Setup(); //Attach RA Menu to Console and Initialise RA System
 		ConsolePrintf("%s (built %s %s)\n(c) %s %s\n--\n", MEKA_NAME_VERSION, MEKA_BUILD_DATE, MEKA_BUILD_TIME, MEKA_DATE, MEKA_AUTHORS);
 	#else
         ConsolePrintf ("\n%s (c) %s %s\n--\n", MEKA_NAME_VERSION, MEKA_DATE, MEKA_AUTHORS);


### PR DESCRIPTION
Shows the version and user in the main Meka window instead of the Console window:
![image](https://user-images.githubusercontent.com/32680403/54093664-d4a44400-435f-11e9-9aa7-04c7e3bd41f9.png)

This should also ensure that popup messages (such as hardcore warnings) are displayed over the main window instead of behind it.

The "RetroAchievements" menu itself is still attached to the Console window. Attempting to move it to the main window caused issues rendering the overlay. I'll investigate that further at a future time.