### PR TITLE
Complete checklist for RAGens

### DIFF
--- a/RAGens/common/src/G_dinput.cpp
+++ b/RAGens/common/src/G_dinput.cpp
@@ -4,6 +4,9 @@
 #include "io.h"
 #include "G_main.h"
 
+// ##RA
+#include "RA_Interface.h"
+
 #define KEYDOWN(key) (Keys[key] & 0x80) 
 #define MAX_JOYS 8
 
@@ -406,6 +409,9 @@ int RewindRequested()
 {
 	if(Check_Key_Pressed(Keys_Def[0].Rewind) || Check_Key_Pressed(Keys_Def[1].Rewind))
 	{
+        if (RA_HardcoreModeIsActive())
+            return 0;
+
 		return 1;
 	}
 	else

--- a/RAGens/common/src/RA_Implementation.cpp
+++ b/RAGens/common/src/RA_Implementation.cpp
@@ -41,8 +41,13 @@ void GetEstimatedGameTitle( char* sNameOut )
 		strcpy_s( sNameOut, 49, Game->Rom_Name_W );
 }
 
+extern int Set_Frame_Skip(HWND hWnd, int Num);
+
 void ResetEmulation()
 {
+    if (Frame_Skip > 0)
+        Set_Frame_Skip(HWnd, -1); // auto
+
 	if (Genesis_Started)
 	{
 		Reset_Genesis();

--- a/RAGens/common/src/gens.h
+++ b/RAGens/common/src/gens.h
@@ -13,7 +13,7 @@ extern "C" {
 #define CLOCK_NTSC 53693175
 #define CLOCK_PAL  53203424
 
-#define GENS_DEBUG
+//#define GENS_DEBUG
 
 extern int Debug;
 extern int Frame_Skip;


### PR DESCRIPTION
* fully disable rewind in hardcore (previously holding the rewind key acted as a sort of slow-motion as it advanced at rewind speed)
* reset speed when switching to hardcore
* remove debuggers (trying to open them caused the emulator to crash)

[RAGens-checklist.txt](https://github.com/RetroAchievements/RAEmus/files/3000733/RAGens-0.58.txt)
