### PR TITLE
Map GB/C RAM banks in RAVBA-M

### DIFF
--- a/RAVBA-M/src/win32/MainWnd.cpp
+++ b/RAVBA-M/src/win32/MainWnd.cpp
@@ -448,6 +448,15 @@ void ByteWriter( size_t nOffs, unsigned char nVal )
 	gbWriteMemory( nOffs, nVal );
 }
 
+unsigned char GBCBankedRAMReader( size_t nOffs )
+{
+	return gbWram[0x1000 + nOffs];
+}
+void GBCBankedRAMWriter( size_t nOffs, unsigned char nVal )
+{
+	gbWram[0x1000 + nOffs] = nVal;
+}
+
 unsigned char GBAByteReaderInternalRAM( size_t nOffs )
 {
 	return static_cast<unsigned char>( internalRAM[ nOffs ] );
@@ -579,6 +588,7 @@ bool MainWnd::FileRun()
 		RA_SetConsoleID( 6 );
 		RA_ClearMemoryBanks();
 		RA_InstallMemoryBank( 0, ByteReader, ByteWriter, 0x10000 );
+		RA_InstallMemoryBank( 1, GBCBankedRAMReader, GBCBankedRAMWriter, 0x7000 );
 		RA_OnLoadNewRom( gbRom, gbRomSize );
 	}
 


### PR DESCRIPTION
Closes #36.

This adds RAM banks to the end of the memory map (offset 0x10000).

For GB, it is a mirror of the 0xD000\~0xDFFF area. For GBC, it is the seven memory banks mapped directly. In most cases, that means 0x10000\~0x10FFF is a mirror of 0xD000\~0xDFFF. On the GB end the bank is remapped for compatibility in case someone decides to use the first static memory bank instead of the banked memory area.

I have corresponding PRs ready to go for the compatible libretro cores when this is merged.