### PR TITLE
update release checklist

### DIFF
--- a/NewEmuChecklist.txt
+++ b/NewEmuChecklist.txt
@@ -71,7 +71,7 @@ RetroAchievements Emulator Requirements:
   [ ] Version generated from git tag
   [ ] Zip file needs to be built - should contain emulator, default Overlay directory, and any supplemental files needed by the emulator
   [ ] Release (to be done by the RAWeb team)
-    [ ] Upload zip file to the server (currently `public/bin/`)
+    [ ] Upload zip file to the server (currently 'public/bin/')
     [ ] Get the emulator's enum from RAInterface.h and add it to RAWeb:src/Emulators.php
     [ ] Add a release entry for the new emulator to lib/database/releases.php on the server (and optionally to RAWeb:lib/database/releases.dist.php) including path to the zip file, latest version and supported systems
     [ ] Add link to the new system's game list in RAWeb:lib/dynrenderer.php>RenderToolbar

--- a/NewEmuChecklist.txt
+++ b/NewEmuChecklist.txt
@@ -70,11 +70,9 @@ RetroAchievements Emulator Requirements:
 [ ] After approval
   [ ] Version generated from git tag
   [ ] Zip file needs to be built - should contain emulator, default Overlay directory, and any supplemental files needed by the emulator
-  [ ] Backend (to be done by the RAWeb team)
-    [ ] Add the emulator's console ID as a "valid" console, so new achievements can be promoted to the Core set (RAWeb:lib/database/release.php>isValidConsoleId).
-    [ ] Add the emulator's enum (get the number from RAInterface.h and add it in RAWeb:src/Emulators.php)
-    [ ] Add an entry for the new emulator in the 'emulators' array in RAWeb:lib/database/releases.dist.php (optional) and lib/database/releases.php on the server.
-    [ ] Add link to the new system game list in RAWeb:lib/dynrenderer.php>RenderToolbar.
-    [ ] Add an entry for the emulator in RAWeb:public/reportissue.php, so people can choose it when opening tickets.
-    [ ] Upload zip file to the server
-    [ ] Add a link to the zip file and show the latest emulator's version in RAWeb:public/download.php 
+  [ ] Release (to be done by the RAWeb team)
+    [ ] Upload zip file to the server (currently `public/bin/`)
+    [ ] Get the emulator's enum from RAInterface.h and add it to RAWeb:src/Emulators.php
+    [ ] Add a release entry for the new emulator to lib/database/releases.php on the server (and optionally to RAWeb:lib/database/releases.dist.php) including path to the zip file, latest version and supported systems
+    [ ] Add link to the new system's game list in RAWeb:lib/dynrenderer.php>RenderToolbar
+    [ ] Add the emulator's console ID as a "valid" console to RAWeb:lib/database/release.php>isValidConsoleId so new achievements can be promoted to the core set


### PR DESCRIPTION
Changes the order of checklist items so that marking the console as valid is the last step; omits some superfluous steps.